### PR TITLE
[DAT-1162] Link data to user via userid instead of username

### DIFF
--- a/libs/deserializer/src/main/java/de/cyface/deserializer/DeserializerFactory.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/DeserializerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -29,6 +29,8 @@ import de.cyface.model.MetaData;
  * A collection of static factory methods to hide the possible complexity of {@link Deserializer} creation.
  * 
  * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 1.0.0
  */
 public final class DeserializerFactory {
 
@@ -59,7 +61,7 @@ public final class DeserializerFactory {
      * in the form of four zip archives. The first contains an SQLite database with the location information and some
      * metadata. The other three contain the sensor data from the accelerometer, the gyroscope and the compass.
      * 
-     * @param username The username of the user who created the data to be deserialized by the created deserializer.
+     * @param userId The id of the user who created the data to be deserialized by the created deserializer.
      *            This information is lost during the export process and needs to be provided here
      * @param measuresArchive The archive containing the SQLite database with the location data
      * @param accelerationsArchive The archive containing the accelerations from the accelerometer
@@ -67,9 +69,9 @@ public final class DeserializerFactory {
      * @param directionsArchive The archive containing directions from the compass
      * @return A {@link ZippedPhoneDataDeserializer} to read measurements from a phone export
      */
-    public static ZippedPhoneDataDeserializer create(final String username, final Path measuresArchive,
+    public static ZippedPhoneDataDeserializer create(final String userId, final Path measuresArchive,
             final Path accelerationsArchive, final Path rotationsArchive, final Path directionsArchive) {
-        return new ZippedPhoneDataDeserializer(username, measuresArchive, accelerationsArchive, rotationsArchive,
+        return new ZippedPhoneDataDeserializer(userId, measuresArchive, accelerationsArchive, rotationsArchive,
                 directionsArchive);
     }
 
@@ -78,7 +80,7 @@ public final class DeserializerFactory {
      * <code>Deserializer</code> is for data that has already been extracted to disk. Therefore, it expects sensor data
      * files as a list of multiple files (one per measurement and sensor data).
      * 
-     * @param username The username of the user who created the data to be deserialized by the created deserializer.
+     * @param userId The id of the user who created the data to be deserialized by the created deserializer.
      *            This information is lost during the export process and needs to be provided here
      * @param measuresDatabase An SQLite database containing the location information
      * @param accelerationFiles The files containing the accelerations from the accelerometer for each measurement
@@ -86,8 +88,8 @@ public final class DeserializerFactory {
      * @param directionFiles The files containing the directions from the compass for each measurement
      * @return A {@link UnzippedPhoneDataDeserializer} to read measurements from an unzipped phone export
      */
-    public static UnzippedPhoneDataDeserializer create(final String username, final Path measuresDatabase,
+    public static UnzippedPhoneDataDeserializer create(final String userId, final Path measuresDatabase,
                                                        final List<Path> accelerationFiles, final List<Path> rotationFiles, final List<Path> directionFiles) {
-        return new UnzippedPhoneDataDeserializer(username, measuresDatabase, accelerationFiles, rotationFiles, directionFiles);
+        return new UnzippedPhoneDataDeserializer(userId, measuresDatabase, accelerationFiles, rotationFiles, directionFiles);
     }
 }

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
@@ -47,7 +47,7 @@ import de.cyface.model.RawRecord;
 
 /**
  * A {@link Deserializer} for phone data exports, that are already unzipped. Each such export consists of an SQLite file
- * containing some meta information, the captured geolocations and user interaction events during capturing. In
+ * containing some meta information, the captured geographic locations and user interaction events during capturing. In
  * addition, there are binary files with the
  * information from the individual <code>Measurement</code>s. There is one such file for each sensor and
  * <code>Measurement</code>. The sensors are the accelerometer (*.cyfa files), the gyroscope (*.cyfr files) and the

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -47,14 +47,16 @@ import de.cyface.model.RawRecord;
 
 /**
  * A {@link Deserializer} for phone data exports, that are already unzipped. Each such export consists of an SQLite file
- * containing some meta information, the captured geo locations and user interaction events during capturing. In
- * addition there are binary files with the
+ * containing some meta information, the captured geolocations and user interaction events during capturing. In
+ * addition, there are binary files with the
  * information from the individual <code>Measurement</code>s. There is one such file for each sensor and
  * <code>Measurement</code>. The sensors are the accelerometer (*.cyfa files), the gyroscope (*.cyfr files) and the
  * compass (*.cyfd files). The name of each file is the <code>Measurement</code> number, which can be used as a foreign
  * key into the database.
  * 
  * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 1.0.0
  */
 public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
     /**
@@ -98,18 +100,18 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
      */
     private final List<Path> directionsFilePaths;
     /**
-     * The username used to identify the deserialized information. This is lost during export. It does not matter to use
-     * the correct one here, but a username is often necessary for further processing steps.
+     * The user id used to identify the deserialized information. This is lost during export. It does not matter to use
+     * the correct one here, but a user id is often necessary for further processing steps.
      */
-    private final String username;
+    private final String userId;
 
     /**
      * Create a new {@link Deserializer} for phone data. Before calling read on an instance of this class
      * {@link #setMeasurementNumber(long)} must have been called with a valid number. The valid numbers are available
      * via {@link #peakIntoDatabase()}.
      * 
-     * @param username The username used to identify the deserialized information. This is lost during export. It does
-     *            not matter to use the correct one here, but a username is often necessary for further processing
+     * @param userId The user id used to identify the deserialized information. This is lost during export. It does
+     *            not matter to use the correct one here, but a user id is often necessary for further processing
      *            steps
      * @param sqliteDatabasePath The path in the local file system to the SQLite database with the location and event
      *            information
@@ -117,9 +119,9 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * @param rotationsFilePaths The files containing the gyroscope sensor data
      * @param directionsFilePaths The files containing the compass sensor data
      */
-    UnzippedPhoneDataDeserializer(final String username, final Path sqliteDatabasePath,
-            final List<Path> accelerationsFilePaths,
-            final List<Path> rotationsFilePaths, final List<Path> directionsFilePaths) {
+    UnzippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath,
+                                  final List<Path> accelerationsFilePaths,
+                                  final List<Path> rotationsFilePaths, final List<Path> directionsFilePaths) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
         Validate.isTrue(accelerationsFilePaths.stream().map(Files::exists)
                 .reduce((first, second) -> first || second).orElseThrow());
@@ -127,13 +129,13 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
                 .reduce((first, second) -> first || second).orElseThrow());
         Validate.isTrue(directionsFilePaths.stream().map(Files::exists)
                 .reduce((first, second) -> first || second).orElseThrow());
-        Validate.notEmpty(username);
+        Validate.notEmpty(userId);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePaths = accelerationsFilePaths;
         this.rotationsFilePaths = rotationsFilePaths;
         this.directionsFilePaths = directionsFilePaths;
-        this.username = username;
+        this.userId = userId;
     }
 
     @Override
@@ -211,7 +213,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
     }
 
     /**
-     * Query the SQLite database for the user interaction events that occured during <code>Measurement</code>.
+     * Query the SQLite database for the user interaction events that occurred during <code>Measurement</code>.
      * 
      * @param connection A JDBC <code>Connection</code> to the SQLite database at {@link #sqliteDatabasePath}
      * @param measurementIdentifier The identifier of the <code>Measurement</code> to load locations for
@@ -242,11 +244,11 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
     }
 
     /**
-     * Query the SQLite database for the meta data of the requested <code>Measurement</code>.
+     * Query the SQLite database for the metadata of the requested <code>Measurement</code>.
      * 
      * @param connection A JDBC <code>Connection</code> to the SQLite database at {@link #sqliteDatabasePath}
      * @param measurementNumber The number of the <code>Measurement</code> to read the data for
-     * @return The meta data for the requested <code>Measurement</code> all fields not stored in the data are set with
+     * @return The metadata for the requested <code>Measurement</code> all fields not stored in the data are set with
      *         default values
      * @throws SQLException If the query was not successful
      */
@@ -266,7 +268,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
         lengthResultSet.next();
         final var length = lengthResultSet.getDouble(1);
         final var version = "1";
-        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, username, version);
+        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, userId, version);
     }
 
     /**

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
@@ -108,7 +108,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
         Validate.isTrue(Files.exists(accelerationsFilePath));
         Validate.isTrue(Files.exists(rotationsFilePath));
         Validate.isTrue(Files.exists(directionsFilePath));
-        Validate.notEmpty(userId);
+        Validate.notEmpty(username);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePath = accelerationsFilePath;

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -28,19 +28,21 @@ import java.util.function.BiConsumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import de.cyface.deserializer.exceptions.InvalidLifecycleEvents;
-import de.cyface.deserializer.exceptions.NoSuchMeasurement;
 import org.apache.commons.lang3.Validate;
 
+import de.cyface.deserializer.exceptions.InvalidLifecycleEvents;
+import de.cyface.deserializer.exceptions.NoSuchMeasurement;
 import de.cyface.model.Measurement;
 import de.cyface.model.MeasurementIdentifier;
 
 /**
  * A {@link Deserializer} for zipped phone data. This is the format as it is returned by the smartphone. This data comes
  * in the form of four zip archives. The first contains an SQLite database with the location information and some
- * meta data. The other three contain the sensor data from the accelerometer, the gyroscope and the compass.
+ * metadata. The other three contain the sensor data from the accelerometer, the gyroscope and the compass.
  * 
  * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 1.0.0
  */
 public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
 
@@ -66,11 +68,10 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      */
     private boolean isUnzipped;
     /**
-     * The username used to identify the deserialized information. This is lost during export. It does
-     * not matter to use the correct one here, but a user name is often necessary for further processing
-     * steps.
+     * The user id used to identify the deserialized information. This is lost during export. It does
+     * not matter to use the correct one here, but a user id is often necessary for further processing steps.
      */
-    private final String username;
+    private final String userId;
     /**
      * The path in the local file system to the SQLite database with the location and event
      * information
@@ -94,28 +95,27 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * * {@link #setMeasurementNumber(long)} must have been called with a valid number. The valid numbers are available
      * * via {@link #peakIntoDatabase()}.
      *
-     * @param username The username used to identify the deserialized information. This is lost during export. It does
-     *            not matter to use the correct one here, but a user name is often necessary for further processing
-     *            steps
+     * @param userId The user id used to identify the deserialized information. This is lost during export. It does
+     *            not matter to use the correct one here, but a user id is often necessary for further processing steps
      * @param sqliteDatabasePath The archive containing the SQLite database with the location data
      * @param accelerationsFilePath The archive containing the accelerations from the accelerometer
      * @param rotationsFilePath The archive containing rotations from the gyroscope
      * @param directionsFilePath The archive containing directions from the compass
      */
-    ZippedPhoneDataDeserializer(final String username, final Path sqliteDatabasePath, final Path accelerationsFilePath,
+    ZippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath, final Path accelerationsFilePath,
             final Path rotationsFilePath, final Path directionsFilePath) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
         Validate.isTrue(Files.exists(accelerationsFilePath));
         Validate.isTrue(Files.exists(rotationsFilePath));
         Validate.isTrue(Files.exists(directionsFilePath));
-        Validate.notEmpty(username);
+        Validate.notEmpty(userId);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePath = accelerationsFilePath;
         this.rotationsFilePath = rotationsFilePath;
         this.directionsFilePath = directionsFilePath;
         this.isUnzipped = false;
-        this.username = username;
+        this.userId = userId;
     }
 
     @Override
@@ -127,7 +127,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
             this.directionPaths = unzip(directionsFilePath);
             isUnzipped = true;
         }
-        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(username, databaseFile, accelerationPaths,
+        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(userId, databaseFile, accelerationPaths,
                 rotationPaths, directionPaths);
         phoneDataDeserializer.setMeasurementNumber(measurementNumber);
 
@@ -161,7 +161,8 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * @return The path to the unzipped entry
      * @throws IOException If unzipping the data fails
      */
-    private Path unzipAndReturnMatching(final Path zipFile, final String nameOfZipFileEntryToReturn)
+    private Path unzipAndReturnMatching(final Path zipFile,
+            @SuppressWarnings("SameParameterValue") final String nameOfZipFileEntryToReturn)
             throws IOException {
         final var onUnzippedAction = new BiConsumer<Path, ZipEntry>() {
 
@@ -200,7 +201,8 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
 
                 final var path = Paths.get(entry.getName());
                 final var fileName = path.getFileName().toString(); // path.endsWith() does not work
-                final var fileExtension = fileName.endsWith(".cyfa") ? ".cyfa" : fileName.endsWith(".cyfr") ? ".cyfr" : fileName.endsWith(".cyfd") ? ".cyfd" : ".tmp";
+                final var fileExtension = fileName.endsWith(".cyfa") ? ".cyfa"
+                        : fileName.endsWith(".cyfr") ? ".cyfr" : fileName.endsWith(".cyfd") ? ".cyfd" : ".tmp";
                 final var tempPath = Files.createTempFile(path.getFileName().toString(), fileExtension);
                 try (final var fos = Files.newOutputStream(tempPath)) {
                     int len;

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
@@ -68,10 +68,10 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      */
     private boolean isUnzipped;
     /**
-     * The username to identify the deserialized information. This is lost during export. It is not necessary
-     * to use the correct one here, but a username is often necessary for further processing steps
+     * The userId to identify the deserialized information. This is lost during export. It is not necessary
+     * to use the correct one here, but a userId is often necessary for further processing steps
      */
-    private final String username;
+    private final String userId;
     /**
      * The path in the local file system to the SQLite database with the location and event
      * information
@@ -95,27 +95,27 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * * {@link #setMeasurementNumber(long)} must have been called with a valid number. The valid numbers are available
      * * via {@link #peakIntoDatabase()}.
      *
-     * @param username The username to identify the deserialized information. This is lost during export. It is not necessary
-     *            to use the correct one here, but a username is often necessary for further processing steps
+     * @param userId The userId to identify the deserialized information. This is lost during export. It is not necessary
+     *            to use the correct one here, but a userId is often necessary for further processing steps
      * @param sqliteDatabasePath The archive containing the SQLite database with the location data
      * @param accelerationsFilePath The archive containing the accelerations from the accelerometer
      * @param rotationsFilePath The archive containing rotations from the gyroscope
      * @param directionsFilePath The archive containing directions from the compass
      */
-    ZippedPhoneDataDeserializer(final String username, final Path sqliteDatabasePath, final Path accelerationsFilePath,
+    ZippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath, final Path accelerationsFilePath,
             final Path rotationsFilePath, final Path directionsFilePath) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
         Validate.isTrue(Files.exists(accelerationsFilePath));
         Validate.isTrue(Files.exists(rotationsFilePath));
         Validate.isTrue(Files.exists(directionsFilePath));
-        Validate.notEmpty(username);
+        Validate.notEmpty(userId);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePath = accelerationsFilePath;
         this.rotationsFilePath = rotationsFilePath;
         this.directionsFilePath = directionsFilePath;
         this.isUnzipped = false;
-        this.username = username;
+        this.userId = userId;
     }
 
     @Override
@@ -127,7 +127,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
             this.directionPaths = unzip(directionsFilePath);
             isUnzipped = true;
         }
-        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(username, databaseFile, accelerationPaths,
+        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(userId, databaseFile, accelerationPaths,
                 rotationPaths, directionPaths);
         phoneDataDeserializer.setMeasurementNumber(measurementNumber);
 

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
@@ -68,10 +68,10 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      */
     private boolean isUnzipped;
     /**
-     * The user id used to identify the deserialized information. This is lost during export. It does
-     * not matter to use the correct one here, but a user id is often necessary for further processing steps.
+     * The username to identify the deserialized information. This is lost during export. It is not necessary
+     * to use the correct one here, but a username is often necessary for further processing steps
      */
-    private final String userId;
+    private final String username;
     /**
      * The path in the local file system to the SQLite database with the location and event
      * information
@@ -95,14 +95,14 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * * {@link #setMeasurementNumber(long)} must have been called with a valid number. The valid numbers are available
      * * via {@link #peakIntoDatabase()}.
      *
-     * @param userId The user id used to identify the deserialized information. This is lost during export. It does
-     *            not matter to use the correct one here, but a user id is often necessary for further processing steps
+     * @param username The username to identify the deserialized information. This is lost during export. It is not necessary
+     *            to use the correct one here, but a username is often necessary for further processing steps
      * @param sqliteDatabasePath The archive containing the SQLite database with the location data
      * @param accelerationsFilePath The archive containing the accelerations from the accelerometer
      * @param rotationsFilePath The archive containing rotations from the gyroscope
      * @param directionsFilePath The archive containing directions from the compass
      */
-    ZippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath, final Path accelerationsFilePath,
+    ZippedPhoneDataDeserializer(final String username, final Path sqliteDatabasePath, final Path accelerationsFilePath,
             final Path rotationsFilePath, final Path directionsFilePath) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
         Validate.isTrue(Files.exists(accelerationsFilePath));
@@ -115,7 +115,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
         this.rotationsFilePath = rotationsFilePath;
         this.directionsFilePath = directionsFilePath;
         this.isUnzipped = false;
-        this.userId = userId;
+        this.username = username;
     }
 
     @Override
@@ -127,7 +127,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
             this.directionPaths = unzip(directionsFilePath);
             isUnzipped = true;
         }
-        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(userId, databaseFile, accelerationPaths,
+        final var phoneDataDeserializer = new UnzippedPhoneDataDeserializer(username, databaseFile, accelerationPaths,
                 rotationPaths, directionPaths);
         phoneDataDeserializer.setMeasurementNumber(measurementNumber);
 

--- a/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
+++ b/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
@@ -73,6 +73,10 @@ class BinaryFormatDeserializerTest {
     private static final long TRACK2_PAUSE_TIME = 1556050163150L;
     private static final long TRACK3_RESUME_TIME = 1556050163200L;
     private static final long MEASUREMENT_STOP_TIME = 1556050163250L;
+    /**
+     * The id of the user to add test data for.
+     */
+    private static final String TEST_USER_ID = "624d8c51c0879068499676c6";
 
     /**
      * This test evaluates the general workings of reading some binary data from a very short file in the Cyface binary
@@ -86,7 +90,7 @@ class BinaryFormatDeserializerTest {
         // Arrange
         final var identifier = new MeasurementIdentifier("test", 1);
         try (final var testData = testData(identifier)) {
-            final var metaData = new MetaData(identifier, "Pixel 3", "Android 9.0.0", "1.2.0-beta1", 500.5, "admin",
+            final var metaData = new MetaData(identifier, "Pixel 3", "Android 9.0.0", "1.2.0-beta1", 500.5, TEST_USER_ID,
                     MetaData.CURRENT_VERSION);
             final var reader = new BinaryFormatDeserializer(metaData, testData);
 
@@ -100,7 +104,7 @@ class BinaryFormatDeserializerTest {
             assertThat(result.getMetaData().getOsVersion(), is("Android 9.0.0"));
             assertThat(result.getMetaData().getAppVersion(), is("1.2.0-beta1"));
             assertThat(result.getMetaData().getLength(), is(500.5));
-            assertThat(result.getMetaData().getUserId(), is("admin"));
+            assertThat(result.getMetaData().getUserId(), is(TEST_USER_ID));
             assertThat(result.getMetaData().getVersion(), is(MetaData.CURRENT_VERSION));
 
             final var resultTracks = result.getTracks();

--- a/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
+++ b/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
@@ -100,7 +100,7 @@ class BinaryFormatDeserializerTest {
             assertThat(result.getMetaData().getOsVersion(), is("Android 9.0.0"));
             assertThat(result.getMetaData().getAppVersion(), is("1.2.0-beta1"));
             assertThat(result.getMetaData().getLength(), is(500.5));
-            assertThat(result.getMetaData().getUsername(), is("admin"));
+            assertThat(result.getMetaData().getUserId(), is("admin"));
             assertThat(result.getMetaData().getVersion(), is(MetaData.CURRENT_VERSION));
 
             final var resultTracks = result.getTracks();

--- a/libs/model/src/main/java/de/cyface/model/MetaData.java
+++ b/libs/model/src/main/java/de/cyface/model/MetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -25,7 +25,7 @@ import java.util.Objects;
  * The context of a {@code Measurement}.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 2.0.0
  * @since 1.2.0
  */
 public class MetaData implements Serializable {
@@ -61,9 +61,9 @@ public class MetaData implements Serializable {
      */
     private double length;
     /**
-     * The name of the user who has uploaded this measurement.
+     * The id of the user who has uploaded this measurement.
      */
-    private String username;
+    private String userId;
     /**
      * The version of the {@code Measurement} model in the deserialized format, such as "1.1.1" or "2.0.0".
      */
@@ -77,17 +77,17 @@ public class MetaData implements Serializable {
      * @param osVersion The operating system version, such as "Android 9.0.0" or "iOS 11.2".
      * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
      * @param length The length of the measurement in meters.
-     * @param username The name of the user who has uploaded this measurement.
+     * @param userId The id of the user who has uploaded this measurement.
      * @param version The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
      */
     public MetaData(final MeasurementIdentifier identifier, final String deviceType, final String osVersion,
-            final String appVersion, final double length, final String username, final String version) {
+            final String appVersion, final double length, final String userId, final String version) {
         this.identifier = identifier;
         this.deviceType = deviceType;
         this.osVersion = osVersion;
         this.appVersion = appVersion;
         this.length = length;
-        this.username = username;
+        this.userId = userId;
         this.version = version;
     }
 
@@ -100,7 +100,7 @@ public class MetaData implements Serializable {
     }
 
     /**
-     * @return The world wide unique identifier of the measurement.
+     * @return The worldwide unique identifier of the measurement.
      */
     public MeasurementIdentifier getIdentifier() {
         return identifier;
@@ -135,10 +135,10 @@ public class MetaData implements Serializable {
     }
 
     /**
-     * @return The name of the user who has uploaded this measurement.
+     * @return The id of the user who has uploaded this measurement.
      */
-    public String getUsername() {
-        return username;
+    public String getUserId() {
+        return userId;
     }
 
     /**
@@ -151,7 +151,7 @@ public class MetaData implements Serializable {
     /**
      * Required by Apache Flink.
      *
-     * @param identifier The world wide unique identifier of the measurement.
+     * @param identifier The worldwide unique identifier of the measurement.
      */
     public void setIdentifier(final MeasurementIdentifier identifier) {
         this.identifier = identifier;
@@ -162,6 +162,7 @@ public class MetaData implements Serializable {
      *
      * @param deviceType The type of device uploading the data, such as "Pixel 3" or "iPhone 6 Plus".
      */
+    @SuppressWarnings("unused")
     public void setDeviceType(final String deviceType) {
         this.deviceType = deviceType;
     }
@@ -171,6 +172,7 @@ public class MetaData implements Serializable {
      *
      * @param osVersion The operating system version, such as "Android 9.0.0" or "iOS 11.2".
      */
+    @SuppressWarnings("unused")
     public void setOsVersion(final String osVersion) {
         this.osVersion = osVersion;
     }
@@ -180,6 +182,7 @@ public class MetaData implements Serializable {
      *
      * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
      */
+    @SuppressWarnings("unused")
     public void setAppVersion(final String appVersion) {
         this.appVersion = appVersion;
     }
@@ -189,6 +192,7 @@ public class MetaData implements Serializable {
      *
      * @param length The length of the measurement in meters.
      */
+    @SuppressWarnings("unused")
     public void setLength(final double length) {
         this.length = length;
     }
@@ -196,10 +200,11 @@ public class MetaData implements Serializable {
     /**
      * Required by Apache Flink.
      *
-     * @param username The name of the user who has uploaded this measurement.
+     * @param userId The name of the user who has uploaded this measurement.
      */
-    public void setUsername(final String username) {
-        this.username = username;
+    @SuppressWarnings("unused")
+    public void setUserId(final String userId) {
+        this.userId = userId;
     }
 
     /**
@@ -219,7 +224,7 @@ public class MetaData implements Serializable {
                 ", osVersion='" + osVersion + '\'' +
                 ", appVersion='" + appVersion + '\'' +
                 ", length=" + length +
-                ", username='" + username + '\'' +
+                ", userId='" + userId + '\'' +
                 ", version='" + version + '\'' +
                 '}';
     }
@@ -236,12 +241,12 @@ public class MetaData implements Serializable {
                 deviceType.equals(metaData.deviceType) &&
                 osVersion.equals(metaData.osVersion) &&
                 appVersion.equals(metaData.appVersion) &&
-                username.equals(metaData.username) &&
+                userId.equals(metaData.userId) &&
                 version.equals(metaData.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(identifier, deviceType, osVersion, appVersion, length, username, version);
+        return Objects.hash(identifier, deviceType, osVersion, appVersion, length, userId, version);
     }
 }

--- a/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
+++ b/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2022 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.0.1
  */
 public class MeasurementTest {
 
@@ -54,6 +54,10 @@ public class MeasurementTest {
      * The name of the user to add test data for.
      */
     private static final String TEST_USER_USERNAME = "guest";
+    /**
+     * The id of the user to add test data for.
+     */
+    private static final String TEST_USER_ID = "624d8c51c0879068499676c6";
 
     /**
      * Tests that writing the CSV header produces the correct output.
@@ -61,7 +65,7 @@ public class MeasurementTest {
     @Test
     void testWriteCsvHeaderRow() {
         // Arrange
-        final var expectedHeader = "username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,"
+        final var expectedHeader = "userId,username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,"
                 + "speed [m/s],accuracy [m],modalityType,modalityTypeDistance [m],distance [m],modalityTypeTravelTime"
                 + " [ms],travelTime [ms]";
 
@@ -91,22 +95,21 @@ public class MeasurementTest {
                                 accuracy(3), speed(3), UNKNOWN)),
                         point3DS, point3DS, point3DS));
         final var measurement = new Measurement(metaData, tracks);
-        final var expectedOutput = "username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,speed [m/s],accuracy [m],modalityType,modalityTypeDistance [m],distance [m],modalityTypeTravelTime [ms],travelTime [ms]\r\n"
-                +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",0,1000," + latitude(1)
-                + ","
+        final var expectedOutput = "userId,username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,"
+                + "speed [m/s],accuracy [m],modalityType,modalityTypeDistance [m],distance [m],"
+                + "modalityTypeTravelTime [ms],travelTime [ms]\r\n"
+                + TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",0,1000," + latitude(1) + ","
                 + longitude(1) + "," + speed(1) + "," + accuracy(1) + "," + UNKNOWN.getDatabaseIdentifier()
-                + ",0.0,0.0,0,0\r\n" +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",1,3000," + latitude(3)
-                + ","
+                + ",0.0,0.0,0,0\r\n"
+                + TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",1,3000," + latitude(3) + ","
                 + longitude(3) + "," + speed(3) + "," + accuracy(3) + "," + UNKNOWN.getDatabaseIdentifier()
                 + ",0.0,0.0,0,0\r\n";
 
         // Act
         final var csvOutput = new StringBuilder();
-        measurement.asCsv(true, line -> {
-            csvOutput.append(line).append("\r\n");
-        });
+        measurement.asCsv(true, TEST_USER_USERNAME, line -> csvOutput.append(line).append("\r\n"));
 
         // Assert
         assertThat(csvOutput.toString(), is(equalTo(expectedOutput)));
@@ -140,30 +143,28 @@ public class MeasurementTest {
         final var measurement = new Measurement(metaData, tracks);
 
         final var csvOutput = new StringBuilder();
-        final var expectedOutput = "username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,speed [m/s],accuracy [m],modalityType,modalityTypeDistance [m],distance [m],modalityTypeTravelTime [ms],travelTime [ms]\r\n"
-                +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",0,1000," + latitude(1)
-                + ","
+        final var expectedOutput = "userId,username,deviceId,measurementId,trackId,timestamp [ms],latitude,longitude,"
+                + "speed [m/s],accuracy [m],modalityType,modalityTypeDistance [m],distance [m],"
+                + "modalityTypeTravelTime [ms],travelTime [ms]\r\n"
+                + TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",0,1000," + latitude(1) + ","
                 + longitude(1) + "," + speed(1) + "," + accuracy(1) + "," + WALKING.getDatabaseIdentifier()
                 + ",0.0,0.0,0,0\r\n" +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",0,1500," + latitude(2)
-                + ","
+                TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",0,1500," + latitude(2) + ","
                 + longitude(2) + "," + speed(2) + "," + accuracy(2) + "," + WALKING.getDatabaseIdentifier()
                 + ",13.12610864737932,13.12610864737932,500,500\r\n" +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",1,3000," + latitude(3)
-                + ","
+                TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",1,3000," + latitude(3) + ","
                 + longitude(3) + "," + speed(3) + "," + accuracy(3) + "," + BICYCLE.getDatabaseIdentifier()
                 + ",0.0,13.12610864737932,0,500\r\n" +
-                TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER + ",1,4000," + latitude(4)
-                + ","
+                TEST_USER_ID + "," + TEST_USER_USERNAME + "," + DEVICE_IDENTIFIER + "," + MEASUREMENT_IDENTIFIER
+                + ",1,4000," + latitude(4) + ","
                 + longitude(4) + "," + speed(4) + "," + accuracy(4) + "," + BICYCLE.getDatabaseIdentifier()
                 + ",13.110048189675535,26.236156837054857,1000,1500\r\n";
 
         // Act
-        measurement.asCsv(true, line -> {
-            csvOutput.append(line).append("\r\n");
-        });
-        // oocut.writeLocationsAsCsvRows(response, measurement);
+        measurement.asCsv(true, TEST_USER_USERNAME, line -> csvOutput.append(line).append("\r\n"));
 
         // Assert
         assertThat(csvOutput.toString(), is(equalTo(expectedOutput)));
@@ -215,7 +216,8 @@ public class MeasurementTest {
                                 speed(1), UNKNOWN)),
                         point3DS, point3DS, point3DS));
         final var measurement = new Measurement(metaData, tracks);
-        final var expectedOutput = "{\"metaData\":{\"username\":\"guest\",\"deviceId\":\""
+        final var expectedOutput = "{\"metaData\":{\"userId\":\"" + TEST_USER_ID
+                + "\",\"username\":\"guest\",\"deviceId\":\""
                 + identifier.getDeviceIdentifier() + "\",\"measurementId\":" + identifier.getMeasurementIdentifier()
                 + ",\"length\":0.0},\"tracks\":[{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\","
                 + "\"geometry\":{\"type\":\"Point\",\"coordinates\":[13.1,51.1]},\"properties\":{\"timestamp\":1000,"
@@ -223,7 +225,7 @@ public class MeasurementTest {
 
         // Act
         final var jsonOutput = new StringBuilder();
-        measurement.asJson(jsonOutput::append);
+        measurement.asJson(TEST_USER_USERNAME, jsonOutput::append);
 
         // Assert
         assertThat(jsonOutput.toString(), is(equalTo(expectedOutput)));
@@ -262,11 +264,11 @@ public class MeasurementTest {
     }
 
     /**
-     * @return A static set of meta data to be used by test {@link Measurement} instances
+     * @return A static set of metadata to be used by test {@link Measurement} instances
      */
     private MetaData metaData() {
         return new MetaData(new MeasurementIdentifier(DEVICE_IDENTIFIER, MEASUREMENT_IDENTIFIER),
                 "Android SDK built for x86", "Android 8.0.0",
-                "2.7.0-beta1", 0.0, TEST_USER_USERNAME, "1.0.0");
+                "2.7.0-beta1", 0.0, TEST_USER_ID, "1.0.0");
     }
 }


### PR DESCRIPTION
As the `username` may reflect the `email` for self-registered users, the likelihood that the `username` value changes increased.

Thus, this PR links the data to the `user` via `user._id` instead of `username` as before.