### PR TITLE
Task/dat 1155 support v1 data migration

### DIFF
--- a/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
@@ -55,7 +55,7 @@ import de.cyface.model.RawRecord;
  * key into the database.
  * 
  * @author Klemens Muthmann
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
@@ -267,8 +267,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
         final var lengthResultSet = lengthQuery.executeQuery();
         lengthResultSet.next();
         final var length = lengthResultSet.getDouble(1);
-        final var version = "1";
-        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, userId, version);
+        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, userId, MetaData.CURRENT_VERSION);
     }
 
     /**

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/BinaryFormatDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/BinaryFormatDeserializer.java
@@ -1,0 +1,199 @@
+package de.cyface.deserializer.v1;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.cyface.model.v1.Event;
+import de.cyface.model.v1.Measurement;
+import de.cyface.model.v1.MeasurementIdentifier;
+import de.cyface.model.v1.MetaData;
+
+/**
+ * A {@link Deserializer} for a file in Cyface binary format. The deserializer requires one file containing the data and
+ * another containing the user events. Constructs a new measurement from a ZLIB compressed <code>InputStream</code> of
+ * data.
+ * <p>
+ * A {@link DeserializerFactory} is necessary to create such a <code>Deserializer</code>.
+ *
+ * @author Klemens Muthmann
+ * @see DeserializerFactory
+ */
+public class BinaryFormatDeserializer implements Deserializer {
+    /**
+     * Used to serialize objects of this class. Only change this if this classes attribute set has changed.
+     */
+    private static final long serialVersionUID = -706300845329533657L;
+    /**
+     * Logger used to log messages from objects of this class. Configure it using <tt>/src/main/resources</tt>.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Deserializer.class);
+    /**
+     * The default value for the parameter "nowrap" used in the Cyface Binary Format. This parameter needs to be passed
+     * to the Inflater's constructor to decompress the compressed bytes.
+     */
+    private static final boolean NOWRAP = true;
+    /**
+     * The current version of the transferred file. This is always specified by the first two bytes of the file
+     * transferred and helps compatible APIs to process data from different client versions.
+     */
+    public static final short TRANSFER_FILE_FORMAT_VERSION = 1;
+    /**
+     * The current version of the transferred file which contains {@link Event}s. This is always specified by the first
+     * two bytes of the file transferred and helps compatible APIs to process data from different client versions.
+     */
+    private static final short EVENT_TRANSFER_FILE_FORMAT_VERSION = 1;
+
+    /**
+     * The meta information about the {@link Measurement}. This information is not part of the datafiles but is usually
+     * stored
+     * alongside the binary data. It is usually used to get a glimpse into what data to expect.
+     */
+    private final MetaData metaData;
+    /**
+     * The events captured for this measurement
+     */
+    private final List<Event> events;
+    /**
+     * The stream of compressed data to load locations and measured data points from
+     */
+    private final InputStream compressedData;
+
+    // FIXME: It makes no sense, that events are provided as a list and the data is provided as a compressed stream.
+    /**
+     * Creates a new completely initialized object of this class. The constructor is not public, since one should use a
+     * {@link DeserializerFactory} to create instances of this class.
+     *
+     * @param metaData The meta information about the {@link Measurement}. This information is not part of the datafiles
+     *            but is usually stored
+     *            * alongside the binary data. It is usually used to get a glimpse into what data to expect
+     * @param events The events captured for this measurement
+     * @param compressedData The stream of compressed data to load locations and measured data points from
+     */
+    BinaryFormatDeserializer(final MetaData metaData, final List<Event> events,
+                             final InputStream compressedData) {
+        Objects.requireNonNull(metaData);
+        Objects.requireNonNull(events);
+        Objects.requireNonNull(compressedData);
+
+        this.metaData = metaData;
+        this.events = new ArrayList<>(events);
+        this.compressedData = compressedData;
+    }
+
+    @Override
+    public Measurement read() throws IOException, InvalidLifecycleEvents {
+        try (InflaterInputStream uncompressedInput = new InflaterInputStream(compressedData, new Inflater(NOWRAP))) {
+            final var version = BinaryFormatParser.readShort(uncompressedInput);
+            if (version != TRANSFER_FILE_FORMAT_VERSION) {
+                LOGGER.error("Encountered data in invalid format. Only Cyface Data Format Version 1 is supported!");
+                return null;
+            }
+
+            final var geoLocationsCount = BinaryFormatParser.readInt(uncompressedInput);
+            final var accelerationsCount = BinaryFormatParser.readInt(uncompressedInput);
+            final var rotationsCount = BinaryFormatParser.readInt(uncompressedInput);
+            final var directionsCount = BinaryFormatParser.readInt(uncompressedInput);
+            final var identifier = metaData.getIdentifier();
+            LOGGER.debug(
+                    "Reading {} geo locations, {} accelerations, {} rotations, {} directions from measurement {}.",
+                    geoLocationsCount, accelerationsCount, rotationsCount, directionsCount, identifier);
+            final var locations = BinaryFormatParser.readGeoLocations(uncompressedInput, geoLocationsCount,
+                    identifier);
+            final var accelerations = BinaryFormatParser.readPoint3Ds(uncompressedInput, accelerationsCount);
+            final var rotations = BinaryFormatParser.readPoint3Ds(uncompressedInput, rotationsCount);
+            final var directions = BinaryFormatParser.readPoint3Ds(uncompressedInput, directionsCount);
+            final var builder = new TrackBuilder();
+            final var tracks = builder.build(locations, events, accelerations, rotations, directions);
+            return new Measurement(metaData, tracks);
+        }
+    }
+
+    @Override
+    public List<MeasurementIdentifier> peakIntoDatabase() throws IOException {
+        return Collections.singletonList(metaData.getIdentifier());
+    }
+
+    /**
+     * Constructs new events from a ZLIB compressed <code>InputStream</code> of data.
+     *
+     * @param input The stream of compressed data to load events data from
+     * @return The list of newly created {@link Event}s
+     * @throws IOException If reading the <code>InputStream</code>, was not successful
+     */
+    static List<Event> readEvents(final InputStream input) throws IOException {
+        final var ret = new ArrayList<Event>();
+        try (var uncompressedInput = new InflaterInputStream(input, new Inflater(NOWRAP))) {
+            var version = BinaryFormatParser.readShort(uncompressedInput);
+            if (version != EVENT_TRANSFER_FILE_FORMAT_VERSION) {
+                throw new IllegalStateException(
+                        "Encountered data in invalid format. Only Cyface Data Format Version 1 is supported!");
+            }
+
+            final var eventsCount = BinaryFormatParser.readInt(uncompressedInput);
+            LOGGER.debug("Reading {} events from events file.", eventsCount);
+            ret.addAll(readEvents(uncompressedInput, eventsCount));
+        }
+        return ret;
+    }
+
+    /**
+     * Reads <code>count</code> events from the <code>input</code> and
+     * provides them in the form of a new <code>BufferedDataTable</code>.
+     *
+     * @param input The stream to read the events from
+     * @param count The number of events to read
+     * @throws IOException If reading the stream fails
+     */
+    static List<Event> readEvents(final InputStream input, final int count) throws IOException {
+        final var events = new ArrayList<Event>(count);
+        for (var i = 0; i < count; i++) {
+            final var timestamp = BinaryFormatParser.readLong(input);
+            final var serializedEventType = BinaryFormatParser.readShort(input);
+            final var valueByteLength = BinaryFormatParser.readShort(input);
+
+            final var eventType = deserializeEventType(serializedEventType);
+            // Value String
+            final var value = BinaryFormatParser.readString(input, valueByteLength);
+            final var event = new Event(eventType, timestamp, value);
+            events.add(event);
+        }
+        LOGGER.debug("Read {} events!", events.size());
+        return events;
+    }
+
+    /**
+     * Converts the {@param serializedEventType} back to it's actual {@link Event.EventType} as defined in
+     * {@link #EVENT_TRANSFER_FILE_FORMAT_VERSION}.
+     * <p>
+     * <b>Attention:</b> Do not break the compatibility in here without increasing the
+     * {@link #EVENT_TRANSFER_FILE_FORMAT_VERSION}.
+     *
+     * @param serializedEventType the serialized value of the actual {@code Event.EventType}
+     * @return the deserialized {@code EventType}
+     */
+    private static Event.EventType deserializeEventType(final short serializedEventType) {
+        switch (serializedEventType) {
+            case 1:
+                return Event.EventType.LIFECYCLE_START;
+            case 2:
+                return Event.EventType.LIFECYCLE_STOP;
+            case 3:
+                return Event.EventType.LIFECYCLE_RESUME;
+            case 4:
+                return Event.EventType.LIFECYCLE_PAUSE;
+            case 5:
+                return Event.EventType.MODALITY_TYPE_CHANGE;
+            default:
+                throw new IllegalArgumentException("Unknown EventType short representation: " + serializedEventType);
+        }
+    }
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/BinaryFormatParser.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/BinaryFormatParser.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2020 Cyface GmbH - All Rights Reserved
+ *
+ * This file is part of the Cyface Server Backend.
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StreamCorruptedException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.cyface.model.v1.MeasurementIdentifier;
+import de.cyface.model.v1.Modality;
+import de.cyface.model.v1.Point3D;
+import de.cyface.model.v1.RawRecord;
+
+/**
+ * An internal class containing utility methods for parsing the Cyface binary format. These methods are used by
+ * different {@link Deserializer} implementations.
+ *
+ * @author Klemens Muthmann
+ */
+class BinaryFormatParser {
+    /**
+     * The logger used by this class. Configure it using <tt>src/main/resources/logback.xml</tt>.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BinaryFormatParser.class);
+    /**
+     * The charset used to parse Strings (e.g. for JSON data)
+     */
+    static final String DEFAULT_CHARSET = "UTF-8";
+
+    /**
+     * Private constructor to avoid instantiation of utility class
+     */
+    private BinaryFormatParser() {
+        // Nothing to do here.
+    }
+
+    /**
+     * Reads <code>count</code> geo locations from the <code>input</code> and
+     * provides them in the form of a new <code>BufferedDataTable</code>.
+     *
+     * @param input The stream to read the geo locations from
+     * @param count The number of geo locations to read
+     * @param identifier the identifier of the locations' measurement
+     * @throws IOException If reading the stream fails
+     */
+    static List<RawRecord> readGeoLocations(final InputStream input, final int count,
+                                            final MeasurementIdentifier identifier) throws IOException {
+        final var locationRecords = new ArrayList<RawRecord>(count);
+        for (var i = 0; i < count; i++) {
+            final var timestamp = readLong(input);
+            final var latitude = readDouble(input);
+            final var longitude = readDouble(input);
+            final var speed = readDouble(input);
+            final var accuracy = readInt(input);
+            final var record = new RawRecord(identifier, timestamp, latitude, longitude, null, accuracy / 100.0,
+                    speed, Modality.UNKNOWN);
+            locationRecords.add(record);
+        }
+        LOGGER.debug("Read {} locations!", locationRecords.size());
+        return locationRecords;
+    }
+
+    /**
+     * Reads <code>count</code> 3D points from the <code>input</code> and provides them in the form of a new
+     * <code>BufferedDataTable</code>. These might be accelerations, rotations or directions ins space.
+     *
+     * @param input The stream to read the points from
+     * @param count The number of points to read
+     * @return The list of {@link Point3D} instances that were part of the provided <code>InputStream</code>.
+     * @throws IOException If reading the stream fails
+     */
+    static List<Point3D> readPoint3Ds(final InputStream input, final int count)
+            throws IOException {
+        final var ret = new ArrayList<Point3D>(count);
+        for (var i = 0; i < count; i++) {
+            LOGGER.trace("Processing {} point3Ds!", i);
+            final var timestamp = readLong(input);
+            final var xValue = readDouble(input);
+            final var yValue = readDouble(input);
+            final var zValue = readDouble(input);
+
+            final var point3D = new Point3D(Double.valueOf(xValue).floatValue(),
+                    Double.valueOf(yValue).floatValue(), Double.valueOf(zValue).floatValue(), timestamp);
+            ret.add(point3D);
+        }
+        Collections.sort(ret);
+        LOGGER.debug("Read {} point3Ds!", ret.size());
+        return ret;
+    }
+
+    /**
+     * Reads the next <code>byteLength</code> bytes from the <code>input</code> as a <code>String</code>.
+     * The bytes should be ordered in Java typical big endian format.
+     *
+     * @param input An open input stream capable of providing at least two bytes of
+     *            data.
+     * @return The <code>short</code> value read from the input stream.
+     * @throws IOException If reading the stream fails
+     */
+    static String readString(final InputStream input, final short byteLength) throws IOException {
+        var buffer = read(input, byteLength);
+        var bytes = buffer.array();
+        return new String(bytes, DEFAULT_CHARSET);
+    }
+
+    /**
+     * Reads the next two byte from the <code>input</code> as a <code>short</code>
+     * value. The bytes should be ordered in Java typical big endian format.
+     *
+     * @param input An open input stream capable of providing at least two bytes of
+     *            data.
+     * @return The <code>short</code> value read from the input stream.
+     * @throws IOException If reading the stream fails
+     */
+    static short readShort(final InputStream input) throws IOException {
+        var shortByteArray = read(input, Short.BYTES);
+        return shortByteArray.getShort();
+    }
+
+    /**
+     * Reads the next four byte from the <code>input</code> as an <code>int</code>
+     * value. The bytes should be ordered in Java typical big endian format.
+     *
+     * @param input An open input stream capable of providing at least four bytes of
+     *            data.
+     * @return The <code>double</code> value read from the input stream.
+     * @throws IOException If reading the stream fails
+     */
+    static int readInt(final InputStream input) throws IOException {
+        return read(input, Integer.BYTES).getInt();
+    }
+
+    /**
+     * Reads the next eight byte from the <code>input</code> as a <code>long</code>
+     * value. The bytes should be ordered in Java typical big endian format.
+     *
+     * @param input An open input stream capable of providing at least eight bytes
+     *            of data.
+     * @return The <code>long</code> value read from the input stream.
+     * @throws IOException If reading the stream fails
+     */
+    static long readLong(final InputStream input) throws IOException {
+        return read(input, Long.BYTES).getLong();
+    }
+
+    /**
+     * Reads the next eight byte from the <code>input</code> as a
+     * <code>double</code> value. The bytes should be ordered in Java typical big
+     * endian format.
+     *
+     * @param input An open input stream capable of providing at least eight bytes
+     *            of data
+     * @return The <code>double</code> value read from the input stream
+     * @throws IOException If reading the stream fails
+     */
+    static double readDouble(final InputStream input) throws IOException {
+        return read(input, Double.BYTES).getDouble();
+    }
+
+    /**
+     * Internal method to read a number of bytes from an <code>InputStream</code> into a <code>ByteBuffer</code>.
+     * The returned <code>ByteBuffer</code> is already prepared for being read again.
+     *
+     * @param input The stream to read the bytes from
+     * @param bytes The number of bytes to read
+     * @return A <code>ByteBuffer</code> containing the bytes
+     * @throws IOException If it was impossible to read <code>bytes</code> from the provided stream
+     */
+    private static ByteBuffer read(final InputStream input, int bytes) throws IOException {
+        final var buffer = ByteBuffer.allocate(bytes);
+        for (var i = 0; i < bytes; i++) {
+            var readByteAsInt = input.read();
+            if (readByteAsInt == -1) {
+                throw new StreamCorruptedException("Unexpected end of stream reached!");
+            }
+            var readByte = (byte)readByteAsInt;
+            buffer.put(readByte);
+        }
+        buffer.position(0);
+        return buffer;
+    }
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/Deserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/Deserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019, 2020 Cyface GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+import de.cyface.model.v1.Measurement;
+import de.cyface.model.v1.MeasurementIdentifier;
+
+/**
+ * Reads {@link Measurement} from the Cyface binary format.
+ *
+ * @author Klemens Muthmann
+ */
+public interface Deserializer extends Serializable {
+    /**
+     * Carry out the actual reading of the {@link Measurement}.
+     *
+     * @return The read <code>Measurement</code>
+     * @throws IOException If reading the binary data fails
+     * @throws InvalidLifecycleEvents If the binary data contains invalid {@link de.cyface.model.Event} instances. This
+     *             might happen if the format of the binary data is newer than the one expected by the
+     *             <code>Deserializer</code>
+     * @throws NoSuchMeasurement If the read <code>Measurement</code> does not fit the information about the requested
+     *             <code>Measurement</code>. It depends on the implementation of the <code>Deserializer</code> if this
+     *             <code>Exception</code> can happen or not. Usually it is thrown if the <code>Deserializer</code> reads
+     *             a <code>Measurement</code> from a source providing multiple <code>Measurement</code>s.
+     */
+    Measurement read() throws IOException, InvalidLifecycleEvents, NoSuchMeasurement;
+    /**
+     * @return A list with all the valid <code>{@link MeasurementIdentifier}</code> within the deserializable data.
+     */
+    List<MeasurementIdentifier> peakIntoDatabase() throws IOException;
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/DeserializerFactory.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/DeserializerFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Cyface GmbH - All Rights Reserved
+ *
+ * This file is part of the Cyface Server Backend.
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import de.cyface.model.v1.MetaData;
+
+/**
+ * A collection of static factory methods to hide the possible complexity of {@link Deserializer} creation.
+ *
+ * @author Klemens Muthmann
+ */
+public final class DeserializerFactory {
+
+    /**
+     * Private constructor to avoid instantiation of static utility class.
+     */
+    private DeserializerFactory() {
+        // Nothing to do here
+    }
+
+    /**
+     * Create a new {@link Deserializer} for a {@link de.cyface.model.Measurement} in Cyface Binary data with its
+     * accompanying events.
+     * Both are provided as compressed input streams, together with the {@link MetaData} about the
+     * <code>Measurement</code>.
+     *
+     * @param metaData The meta information about the <code>Measurement</code> to load
+     * @param compressedEventsDataStream The compressed input stream containing the event data in binary format
+     * @param compressedDataStream The compressed input stream containing the <code>Measurement</code> data in Cyface
+     *            binary format
+     * @return A <code>Deserializer</code> for the Cyface binary format
+     * @throws IOException
+     */
+    public static BinaryFormatDeserializer create(final MetaData metaData, final InputStream compressedEventsDataStream,
+                                                  final InputStream compressedDataStream) throws IOException {
+        final var events = BinaryFormatDeserializer.readEvents(compressedEventsDataStream);
+        return new BinaryFormatDeserializer(metaData, events, compressedDataStream);
+    }
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/InvalidLifecycleEvents.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/InvalidLifecycleEvents.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Cyface GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+/**
+ * This <code>Exception</code> is thrown if the sequence of {@code de.cyface.model.Event}s is invalid.
+ * <p>
+ * E.g.:
+ * - {@link de.cyface.model.Event.EventType#LIFECYCLE_RESUME} event recorded without prior pause event. [VIC-263]
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 1.3.0
+ */
+public class InvalidLifecycleEvents extends Exception {
+    /**
+     * Used to serialize objects of this class. Only change this value if the attribute set changes.
+     */
+    private static final long serialVersionUID = 1971945670723702382L;
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param message An error message to display
+     */
+    @SuppressWarnings("unused") // API
+    public InvalidLifecycleEvents(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param message An error message to display
+     * @param cause The stacktrace which lead to this exception
+     */
+    @SuppressWarnings("unused") // API
+    public InvalidLifecycleEvents(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/NoSuchMeasurement.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/NoSuchMeasurement.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020 Cyface GmbH - All Rights Reserved
+ *
+ * This file is part of the Cyface Server Backend.
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+/**
+ * An <code>Exception</code> that is thrown when a {@link Deserializer} can not read the requested
+ * {@link de.cyface.model.Measurement}.
+ * This may only occur on <code>Deserializer</code>s reading from a source with multiple <code>Measurement</code>s such
+ * as a phone data export.
+ *
+ * @author Klemens Muthmann
+ */
+public class NoSuchMeasurement extends Throwable {
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/TrackBuilder.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/TrackBuilder.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2020 Cyface GmbH - All Rights Reserved
+ *
+ * This file is part of the Cyface Server Backend.
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.commons.lang3.Validate;
+
+import de.cyface.model.v1.DataPoint;
+import de.cyface.model.v1.Event;
+import de.cyface.model.v1.GeoLocation;
+import de.cyface.model.v1.Modality;
+import de.cyface.model.v1.Point3D;
+import de.cyface.model.v1.RawRecord;
+import de.cyface.model.v1.Track;
+
+/**
+ * Builds {@code Track}s from cyface measurement data.
+ * <p>
+ * This allows to analyse and visualize measurements without the need to handle {@code Event}s:
+ * - {@code GeoLocation}s are collected into {@code Track}s and can be visualized by simply connecting all locations
+ * - {@code GeoLocation}s are annotated with the {@code Modality} used to collect the location
+ * - {@code Point3D} data is collected into {@code Track}s and can be analyzed together with the location data
+ *
+ * @author Armin Schnabel
+ * @author Klemens Muthmann
+ */
+final class TrackBuilder {
+    /**
+     * Extracts the tracks from a measurement using its LIFECYCLE Events.
+     *
+     * @param locationRecords of the {@code Measurement} to export the tracks for
+     * @param events the {@code Event}s used to slice the tracks
+     * @param accelerations of the {@code Measurement}
+     * @param rotations of the {@code Measurement}
+     * @param directions of the {@code Measurement}
+     * @return a list of {@link Track}s.
+     * @throws InvalidLifecycleEvents when the sequence of {@code de.cyface.model.Event}s is invalid.
+     */
+    List<Track> build(final List<RawRecord> locationRecords, final List<Event> events,
+                      final List<Point3D> accelerations, final List<Point3D> rotations, final List<Point3D> directions)
+            throws InvalidLifecycleEvents {
+        final Iterator<Event> pauseResumeEventsIterator = events
+                .parallelStream()
+                .filter(event -> event.getType()
+                        .equals(Event.EventType.LIFECYCLE_PAUSE)
+                        || event.getType()
+                        .equals(Event.EventType.LIFECYCLE_RESUME))
+                .iterator();
+        final Iterator<Event> modalityTypeChangesIterator = events
+                .parallelStream()
+                .filter(event -> event.getType()
+                        .equals(Event.EventType.MODALITY_TYPE_CHANGE))
+                .iterator();
+        final ListIterator<RawRecord> geoLocationIterator = locationRecords.listIterator();
+        final ListIterator<Point3D> accelerationsIterator = accelerations.listIterator();
+        final ListIterator<Point3D> rotationsIterator = rotations.listIterator();
+        final ListIterator<Point3D> directionsIterator = directions.listIterator();
+        final List<Track> tracks = loadTracks(geoLocationIterator, pauseResumeEventsIterator, accelerationsIterator,
+                rotationsIterator, directionsIterator);
+        return annotateModalityTypes(tracks, modalityTypeChangesIterator);
+    }
+
+    /**
+     * Sets the {@link Modality} types for all locations of a measurement's track list.
+     *
+     * @param tracks The ordered tracks of a measurement to be annotated.
+     * @param modalityTypeChangesIterator The {@code Event} cursor pointing to the events of modality type changes.
+     * @return the annotated tracks
+     */
+    private List<Track> annotateModalityTypes(final List<Track> tracks,
+                                              final Iterator<Event> modalityTypeChangesIterator) {
+
+        // ModalityType annotation - UNKNOWN if all ModalityTypeChanges were deleted by the user
+        final Modality[] modalityType = {modalityTypeChangesIterator.hasNext()
+                ? Modality.valueOf(modalityTypeChangesIterator.next().getValue())
+                : Modality.UNKNOWN};
+        final Event[] nextModalityTypeChange = {
+                modalityTypeChangesIterator.hasNext() ? modalityTypeChangesIterator.next()
+                        : null};
+
+        tracks.forEach(track -> track.getLocationRecords().forEach(location -> {
+            // Check if the modalityType changed
+            if (nextModalityTypeChange[0] != null
+                    && location.getTimestamp() >= nextModalityTypeChange[0].getTimestamp()) {
+                final String modalityValue = nextModalityTypeChange[0].getValue();
+                Validate.notNull(modalityValue, "Value in ModalityTypeChange event is null");
+                Validate.notEmpty(modalityValue, "Empty value in ModalityTypeChange event");
+                modalityType[0] = Modality.valueOf(modalityValue);
+                Validate.notNull(modalityType[0], "Modality is null");
+                nextModalityTypeChange[0] = modalityTypeChangesIterator.hasNext()
+                        ? modalityTypeChangesIterator.next()
+                        : null;
+            }
+
+            // Annotate location
+            location.setModality(modalityType[0]);
+        }));
+
+        return tracks;
+    }
+
+    /**
+     * Loads the {@link Track}s for the provided {@link GeoLocation} cursor sliced using the provided
+     * {@link Event} cursor.
+     * <p>
+     * From Android SDK 5.0.0-beta1's PersistenceLayer.loadTracks(Cursor, Cursor) implementation.
+     *
+     * @param locationIterator The {@code GeoLocation} cursor which points to the locations to be loaded.
+     * @param eventIterator The {@code Event} cursor pointing to the events of the track to be loaded.
+     * @param accelerationsIterator The cursor pointing to the accelerations to be loaded into the track
+     * @param rotationsIterator The cursor pointing to the rotations to be loaded into the track
+     * @param directionsIterator The cursor pointing to the directions to be loaded into the track
+     * @return The {@link Track}s for the corresponding {@code Measurement} loaded.
+     * @throws InvalidLifecycleEvents when the sequence of {@code de.cyface.model.Event}s is invalid.
+     */
+    private List<Track> loadTracks(final ListIterator<RawRecord> locationIterator,
+                                   final Iterator<Event> eventIterator, final ListIterator<Point3D> accelerationsIterator,
+                                   final ListIterator<Point3D> rotationsIterator, final ListIterator<Point3D> directionsIterator)
+            throws InvalidLifecycleEvents {
+        final List<Track> tracks = new ArrayList<>();
+
+        // Slice Tracks before resume events
+        Long pauseEventTime = null;
+        // `geoLocationIterator.next()` always points to the first GeoLocation of the next sub track or else to null
+        while (eventIterator.hasNext() && locationIterator.hasNext()) {
+            final Event event = eventIterator.next();
+
+            // Search for next resume event and capture it's previous pause event
+            if (event.getType() != Event.EventType.LIFECYCLE_RESUME) {
+                if (event.getType() == Event.EventType.LIFECYCLE_PAUSE) {
+                    pauseEventTime = event.getTimestamp();
+                }
+                continue;
+            }
+            if (pauseEventTime == null) {
+                throw new InvalidLifecycleEvents("Resume event without prior pause event collected.");
+            }
+            final long resumeEventTime = event.getTimestamp();
+
+            // Collect all GeoLocations until the pause event.
+            // The geoLocationIterator then points to the next location after the pause event or to null if finished
+            final Track track = collectNextSubTrack(locationIterator, pauseEventTime, accelerationsIterator,
+                    rotationsIterator, directionsIterator);
+            // Add sub-track to track
+            if (track.getLocationRecords().size() > 0) {
+                tracks.add(track);
+            }
+
+            // The iterator's next points to the second point of the next track
+            // If there is no second point we won't create a track out of one point so we can skip this
+            if (locationIterator.hasNext()) {
+                // Pause reached: Move geoLocationIterator to the first location of the next sub-track
+                // We do this to ignore locations between pause and resume event (STAD-140)
+                moveIteratorToLastBefore(locationIterator, resumeEventTime);
+                moveIteratorToLastBefore(accelerationsIterator, resumeEventTime);
+                moveIteratorToLastBefore(rotationsIterator, resumeEventTime);
+                moveIteratorToLastBefore(directionsIterator, resumeEventTime);
+            }
+        }
+
+        // Collect tail sub track
+        // This is either the track between start[, pause] and stop or resume[, pause] and stop.
+        final Track tail = collectTail(locationIterator, accelerationsIterator, rotationsIterator,
+                directionsIterator);
+        if (tail.getLocationRecords().size() > 0) {
+            tracks.add(tail);
+        }
+        return tracks;
+    }
+
+    /**
+     * Collects all remaining entries.
+     *
+     * @param geoLocationIterator The {@code GeoLocation} cursor which points to the locations to be loaded.
+     * @param accelerationsIterator The cursor pointing to the accelerations to be loaded into the track
+     * @param rotationsIterator The cursor pointing to the rotations to be loaded into the track
+     * @param directionsIterator The cursor pointing to the directions to be loaded into the track
+     * @return the track with the remaining entries
+     */
+    private Track collectTail(final ListIterator<RawRecord> geoLocationIterator,
+                              final ListIterator<Point3D> accelerationsIterator, final ListIterator<Point3D> rotationsIterator,
+                              final ListIterator<Point3D> directionsIterator) {
+        final var locations = new ArrayList<RawRecord>();
+        while (geoLocationIterator.hasNext()) {
+            locations.add(geoLocationIterator.next());
+        }
+        final var accelerations = new ArrayList<Point3D>();
+        while (accelerationsIterator.hasNext()) {
+            accelerations.add(accelerationsIterator.next());
+        }
+        final var rotations = new ArrayList<Point3D>();
+        while (rotationsIterator.hasNext()) {
+            rotations.add(rotationsIterator.next());
+        }
+        final var directions = new ArrayList<Point3D>();
+        while (directionsIterator.hasNext()) {
+            directions.add(directionsIterator.next());
+        }
+        return new Track(locations, accelerations, rotations, directions);
+    }
+
+    /**
+     * Collects a sub {@link Track} of a {@code Measurement}.
+     *
+     * @param geoLocationIterator The {@code Iterator} of which the {@code next()} method points to the
+     *            first {@code GeoLocation} of the sub track to be collected.
+     * @param pauseEventTime the Unix timestamp of the {@link Event.EventType#LIFECYCLE_PAUSE} which defines the end of
+     *            this sub Track.
+     * @param accelerationsIterator The {@code Iterator} of which the {@code next()} method points to the first
+     *            acceleration of the sub track to be collected.
+     * @param rotationsIterator The {@code Iterator} of which the {@code next()} method points to the first
+     *            rotation of the sub track to be collected.
+     * @param directionsIterator The {@code Iterator} of which the {@code next()} method points to the first
+     *            direction of the sub track to be collected.
+     * @return The sub {@code Track}. The {@code geoLocationIterator#next()} now points to the first
+     *         {@code GeoLocation} which is later in time than the {@code pauseEventTime} or {@code null} if the
+     *         earlier does not exist. The same is the case for the {@code Point3D} iterators supplied.
+     */
+    private Track collectNextSubTrack(final ListIterator<RawRecord> geoLocationIterator,
+                                      final Long pauseEventTime, final ListIterator<Point3D> accelerationsIterator,
+                                      final ListIterator<Point3D> rotationsIterator,
+                                      final ListIterator<Point3D> directionsIterator) {
+
+        final var locations = collectUntil(pauseEventTime, geoLocationIterator);
+        final var accelerations = collectUntil(pauseEventTime, accelerationsIterator);
+        final var rotations = collectUntil(pauseEventTime, rotationsIterator);
+        final var directions = collectUntil(pauseEventTime, directionsIterator);
+
+        return new Track(locations, accelerations, rotations, directions);
+    }
+
+    /**
+     * Iterates through a given iterator and collects all entries until the iterator points to an entry which was
+     * captured after a given timestamp.
+     *
+     * @param <T> the Type of the entries to iterator over.
+     * @param iterator of which the {@code next()} method points to the first entry to be collected.
+     * @param pauseEventTime the Unix timestamp which defines the barrier until which entries are collected.
+     * @return the list of entries collected
+     */
+    private <T extends DataPoint> List<T> collectUntil(final Long pauseEventTime,
+                                                       final ListIterator<T> iterator) {
+        List<T> collection = new ArrayList<>();
+        T entry = iterator.next();
+        while (entry != null && entry.getTimestamp() <= pauseEventTime) {
+            collection.add(entry);
+
+            // Load next entry to check it's timestamp in next iteration
+            entry = iterator.hasNext() ? iterator.next() : null;
+        }
+        return collection;
+    }
+
+    /**
+     * Moves the {@code iterator} to the last {@code DataPoint} before {@code resumeEventTime}.
+     * <p>
+     * If there is no such {@code DataPoint} then the iterator points to {@code null}.
+     * <p>
+     * Also points to {@code null} if it points to a null element in the beginning.
+     *
+     * @param <T> the Type of the entries to iterator over.
+     * @param iterator The {@code Iterator} pointing to the {@code DataPoint}s.
+     * @param resumeEventTime the Unix timestamp, e.g. of {@link Event.EventType#LIFECYCLE_RESUME}
+     */
+    <T extends DataPoint> void moveIteratorToLastBefore(final ListIterator<T> iterator, final long resumeEventTime) {
+        iterator.previous();
+        DataPoint point = iterator.next();
+
+        // When the iterator's next() points to "before the event"
+        if (point != null && point.getTimestamp() < resumeEventTime) {
+            // Move forward until we reach the event time
+            while (point != null && point.getTimestamp() < resumeEventTime) {
+                // Load next location to check it's timestamp
+                point = iterator.hasNext() ? iterator.next() : null;
+            }
+            iterator.previous();
+            return;
+        }
+
+        // When the iterator's next() points to "after the event"
+        // Move backward until we pass the event time
+        while (point != null && point.getTimestamp() >= resumeEventTime) {
+            // Load previous location to check it's timestamp
+            point = iterator.hasPrevious() ? iterator.previous() : null;
+        }
+        iterator.next();
+    }
+}

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/v1/UnsupportedFileVersion.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/v1/UnsupportedFileVersion.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Cyface GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.deserializer.v1;
+
+/**
+ * This {@code Exception} is thrown when a file of a deprecated or not yet supported file format is to be processed.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 5.0.0
+ */
+public class UnsupportedFileVersion extends Exception {
+    /**
+     * Used to serialize objects of this class. Only change this value if the attribute set changes.
+     */
+    private static final long serialVersionUID = -3574350415381849173L;
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param message An error message to display
+     */
+    @SuppressWarnings("unused") // API
+    public UnsupportedFileVersion(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of this class.
+     *
+     * @param message An error message to display
+     * @param cause The stacktrace which lead to this exception
+     */
+    @SuppressWarnings("unused") // API
+    public UnsupportedFileVersion(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/Json.java
+++ b/libs/model/src/main/java/de/cyface/model/Json.java
@@ -207,13 +207,24 @@ public class Json {
             private final List<KeyValuePair> keyValuePairs = new ArrayList<>();
 
             /**
-             * Adds the supplied {@code objects} to this builder.
+             * Adds the supplied {@code pair} to this builder.
              *
              * @param pair the {@link KeyValuePair} to add
              * @return this builder
              */
             public Builder add(final KeyValuePair pair) {
                 this.keyValuePairs.add(pair);
+                return this;
+            }
+
+            /**
+             * Adds the supplied {@code pairs} to this builder.
+             *
+             * @param pairs the {@link KeyValuePair}s to add
+             * @return this builder
+             */
+            public Builder addAll(final KeyValuePair... pairs) {
+                this.keyValuePairs.addAll(List.of(pairs));
                 return this;
             }
 
@@ -278,13 +289,24 @@ public class Json {
             private final List<JsonObject> objects = new ArrayList<>();
 
             /**
-             * Adds the supplied {@code objects} to this builder.
+             * Adds the supplied {@code object} to this builder.
              *
              * @param object the {@link JsonObject} to add
              * @return this builder
              */
             public Builder add(final JsonObject object) {
                 this.objects.add(object);
+                return this;
+            }
+
+            /**
+             * Adds the supplied {@code objects} to this builder.
+             *
+             * @param objects the {@link JsonObject}s to add
+             * @return this builder
+             */
+            public Builder addAll(final JsonObject... objects) {
+                this.objects.addAll(List.of(objects));
                 return this;
             }
 

--- a/libs/model/src/main/java/de/cyface/model/Json.java
+++ b/libs/model/src/main/java/de/cyface/model/Json.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @author Armin Schnabel
  * @since 1.1.0
- * @version 1.1.1
+ * @version 1.2.0
  */
 public class Json {
 

--- a/libs/model/src/main/java/de/cyface/model/Measurement.java
+++ b/libs/model/src/main/java/de/cyface/model/Measurement.java
@@ -21,15 +21,21 @@ package de.cyface.model;
 import static de.cyface.model.Json.jsonArray;
 import static de.cyface.model.Json.jsonKeyValue;
 import static de.cyface.model.Json.jsonObject;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -45,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.0.0
+ * @version 2.1.0
  * @since 1.0.0
  */
 public class Measurement implements Serializable {
@@ -87,6 +93,64 @@ public class Measurement implements Serializable {
 
         this.metaData = metaData;
         this.tracks = new ArrayList<>(tracks);
+    }
+
+    public Measurement(final List<TrackBucket> buckets) {
+        if (buckets.isEmpty()) {
+            throw new IllegalArgumentException("Cannot create a measurement from 0 buckets!");
+        }
+        final var metaData = buckets.get(0).getMetaData();
+        Validate.notNull(metaData);
+
+        this.metaData = metaData;
+        final var tracks = tracks(buckets);
+        this.tracks = new ArrayList<>(tracks);
+    }
+
+    /**
+     * Merges {@link TrackBucket}s into {@link Track}s.
+     *
+     * @param trackBuckets the data to merge
+     * @return the tracks
+     */
+    public List<Track> tracks(final List<TrackBucket> trackBuckets) {
+
+        // Group by trackId
+        final var groupedBuckets = trackBuckets.stream()
+                .collect(groupingBy(TrackBucket::getTrackId));
+
+        // Sort bucket groups by trackId
+        final var sortedBucketGroups = groupedBuckets.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new));
+
+        // Convert buckets to Track
+        final var tracks = new ArrayList<Track>();
+        sortedBucketGroups.forEach((trackId, bucketGroup) -> {
+            // Sort buckets
+            final var sortedBuckets = bucketGroup.stream()
+                    .sorted(Comparator.comparing(TrackBucket::getBucket))
+                    .collect(toList());
+
+            // Merge buckets
+            final var locations = sortedBuckets.stream()
+                    .flatMap(bucket -> bucket.getTrack().getLocationRecords().stream())
+                    .collect(Collectors.toList());
+            final var accelerations = sortedBuckets.stream()
+                    .flatMap(bucket -> bucket.getTrack().getAccelerations().stream())
+                    .collect(Collectors.toList());
+            final var rotations = sortedBuckets.stream()
+                    .flatMap(bucket -> bucket.getTrack().getRotations().stream())
+                    .collect(Collectors.toList());
+            final var directions = sortedBuckets.stream()
+                    .flatMap(bucket -> bucket.getTrack().getDirections().stream())
+                    .collect(Collectors.toList());
+
+            final var track = new Track(locations, accelerations, rotations, directions);
+            tracks.add(track);
+        });
+        return tracks;
     }
 
     /**

--- a/libs/model/src/main/java/de/cyface/model/Measurement.java
+++ b/libs/model/src/main/java/de/cyface/model/Measurement.java
@@ -113,7 +113,7 @@ public class Measurement implements Serializable {
      * @param trackBuckets the data to merge
      * @return the tracks
      */
-    public List<Track> tracks(final List<TrackBucket> trackBuckets) {
+    private List<Track> tracks(final List<TrackBucket> trackBuckets) {
 
         // Group by trackId
         final var groupedBuckets = trackBuckets.stream()

--- a/libs/model/src/main/java/de/cyface/model/MetaData.java
+++ b/libs/model/src/main/java/de/cyface/model/MetaData.java
@@ -18,6 +18,8 @@
  */
 package de.cyface.model;
 
+import org.apache.commons.lang3.Validate;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -25,17 +27,21 @@ import java.util.Objects;
  * The context of a {@code Measurement}.
  *
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 2.0.1
  * @since 1.2.0
  */
 public class MetaData implements Serializable {
 
     /**
-     * The version of the deserialized measurement model.
+     * The current version of the deserialized measurement model.
      * <p>
      * Required to read measurement documents from the database which were deserialized by different deserializers.
      */
     public static final String CURRENT_VERSION = "2.0.0";
+    /**
+     * Regex of supported {@link MetaData} versions of this class.
+     */
+    public static final String SUPPORTED_VERSIONS = "2.[0-9]+.[0-9]+";
     /**
      * Used to serialize objects of this class. Only change this value if this classes attribute set changes.
      */
@@ -65,7 +71,7 @@ public class MetaData implements Serializable {
      */
     private String userId;
     /**
-     * The version of the {@code Measurement} model in the deserialized format, such as "1.1.1" or "2.0.0".
+     * The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
      */
     private String version;
 
@@ -78,10 +84,12 @@ public class MetaData implements Serializable {
      * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
      * @param length The length of the measurement in meters.
      * @param userId The id of the user who has uploaded this measurement.
-     * @param version The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
+     * @param version The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
      */
     public MetaData(final MeasurementIdentifier identifier, final String deviceType, final String osVersion,
             final String appVersion, final double length, final String userId, final String version) {
+
+        Validate.isTrue(version.matches(SUPPORTED_VERSIONS), "Unsupported version: %s", version);
         this.identifier = identifier;
         this.deviceType = deviceType;
         this.osVersion = osVersion;

--- a/libs/model/src/main/java/de/cyface/model/TrackBucket.java
+++ b/libs/model/src/main/java/de/cyface/model/TrackBucket.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021-2022 Cyface GmbH
+ *
+ * This file is part of the Serialization.
+ *
+ * The Serialization is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Serialization is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Serialization. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model;
+
+import java.util.Date;
+
+
+/**
+ * The mongo database "bucket" which contains a slice of a track.
+ *
+ * @author Armin Schnabel
+ * @since 1.5.0
+ * @version 1.0.0
+ */
+@SuppressWarnings("unused") // Part of the API
+public class TrackBucket {
+
+    /**
+     * The track's position within the measurement.
+     */
+    final int trackId;
+    /**
+     * The time "slice" of the bucket.
+     */
+    final Date bucket;
+    /**
+     * The track slice of the bucket.
+     */
+    final Track track;
+    /**
+     * The {@link MetaData} of the track.
+     */
+    final MetaData metaData;
+
+    /**
+     * Initialized a fully constructed instance of this class.
+     *
+     * @param trackId The track's position within the measurement.
+     * @param bucket The time "slice" of the bucket.
+     * @param track The track slice of the bucket.
+     * @param metaData The {@link MetaData} of the track.
+     */
+    public TrackBucket(final int trackId, final Date bucket, final Track track, final MetaData metaData) {
+        this.trackId = trackId;
+        this.bucket = bucket;
+        this.track = track;
+        this.metaData = metaData;
+    }
+
+    /**
+     * @return The track's position within the measurement.
+     */
+    public int getTrackId() {
+        return trackId;
+    }
+
+    /**
+     * @return The time "slice" of the bucket.
+     */
+    public Date getBucket() {
+        return bucket;
+    }
+
+    /**
+     * @return The track slice of the bucket.
+     */
+    public Track getTrack() {
+        return track;
+    }
+
+    /**
+     * @return The {@link MetaData} of the track.
+     */
+    public MetaData getMetaData() {
+        return metaData;
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/DataPoint.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/DataPoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+/**
+ * A single point of data such as a geolocation or an acceleration measurement. <code>DataPoint</code> instances are
+ * <code>Comparable</code> based on their timestamp from earliest to latest.
+ *
+ * @author Klemens Muthmann
+ */
+public interface DataPoint extends Comparable<DataPoint> {
+    /**
+     * @return The Unix timestamp at which this <code>DataPoint</code> was measured in milliseconds since the first of
+     *         January 1970.
+     */
+    long getTimestamp();
+
+    /**
+     * @param timestamp The Unix timestamp at which this <code>DataPoint</code> was measured in milliseconds since the
+     *            first of January 1970.
+     */
+    void setTimestamp(final long timestamp);
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/Event.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/Event.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import org.apache.commons.lang3.Validate;
+
+import java.util.Arrays;
+
+/**
+ * A user interaction event, that occurred during a measurement. These events are uploaded alongside the data, as an
+ * event log file in a proprietary binary format.
+ *
+ * @author Klemens Muthmann
+ * @author Armin Schnabel
+ * @since 2.0.1
+ * @version 1.1.0
+ */
+public final class Event {
+    /**
+     * The free form <code>String</code> value of this event. This might be <code>null</code>, if the event has no such
+     * value.
+     */
+    private final String value;
+    /**
+     * The {@code EventType} collected by this {@link Event}.
+     */
+    private final EventType type;
+    /**
+     * The timestamp at which this {@code Event} was captured in milliseconds since 1.1.1970.
+     */
+    private final long timestamp;
+
+    /**
+     * @param value The free form <code>String</code> value of this event. This might be <code>null</code>, if the event
+     *            has no such value
+     * @param type The {@code EventType} collected by this {@link Event}
+     * @param timestamp The timestamp at which this {@code Event} was captured in milliseconds since 1.1.1970
+     */
+    public Event(final EventType type, final long timestamp, final String value) {
+        Validate.isTrue(timestamp >= 0L, "Event timestamp must be larger/equal then zero, but was {}", timestamp);
+
+        this.value = value;
+        this.type = type;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @return The free form <code>String</code> value of this event. This might be <code>null</code>, if the event has
+     *         no such value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return The {@code EventType} collected by this {@link Event}
+     */
+    public EventType getType() {
+        return type;
+    }
+
+    /**
+     * @return The timestamp at which this {@code Event} was captured in milliseconds since 1.1.1970
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Event event = (Event)o;
+
+        // (1) not available in this minSDK version (2) value is null when a LIFECYCLE event is stored
+        // noinspection EqualsReplaceableByObjectsCall
+        return timestamp == event.timestamp &&
+                (value == null ? event.value == null : value.equals(event.value)) &&
+                type == event.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(new Object[] {type, timestamp, value});
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                ", type=" + type +
+                ", timestamp=" + timestamp +
+                ", value='" + value + '\'' +
+                '}';
+    }
+
+    /**
+     * Defines the {@code EventType}s which may be collected.
+     * <p>
+     * An example are the use of the life-cycle methods such as start, pause, resume, etc. which are required to
+     * slice {@link Measurement}s into {@link Track}s before they are resumed.
+     *
+     * @author Armin Schnabel
+     * @version 1.0.1
+     * @since 2.0.0
+     */
+    public enum EventType {
+        /**
+         * This event occurs at the start of a measurement.
+         */
+        LIFECYCLE_START("LIFECYCLE_START"),
+        /**
+         * This event occurs when a measurement is paused.
+         */
+        LIFECYCLE_PAUSE("LIFECYCLE_PAUSE"),
+        /**
+         * This event occurs when a measurement is resumed.
+         */
+        LIFECYCLE_RESUME("LIFECYCLE_RESUME"),
+        /**
+         * This event occurs when a measurement is stopped.
+         */
+        LIFECYCLE_STOP("LIFECYCLE_STOP"),
+        /**
+         * This event occurs if the mode of transportation changes during a measurement.
+         */
+        MODALITY_TYPE_CHANGE("MODALITY_TYPE_CHANGE");
+
+        /**
+         * The event types identifier within the database.
+         */
+        private final String databaseIdentifier;
+
+        /**
+         * Creates a new <code>EventType</code> enum case. Since this is an enumeration the constructor is not visible.
+         *
+         * @param databaseIdentifier The event types identifier within the database
+         */
+        EventType(final String databaseIdentifier) {
+            this.databaseIdentifier = databaseIdentifier;
+        }
+
+        /**
+         * @return The event types identifier within the database
+         */
+        public String getDatabaseIdentifier() {
+            return databaseIdentifier;
+        }
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/GeoLocation.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/GeoLocation.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2019, 2020 Cyface GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+package de.cyface.model.v1;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A model POJO representing a geographical location measured in latitude and longitude. Typically on earth, but this
+ * would work on other planets too, as soon as we require road maintenance there.
+ * <p>
+ * A record of such a location is represented by a {@link GeoLocationRecord}.
+ *
+ * @author Armin Schnabel
+ * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+public class GeoLocation {
+    /**
+     * The logger used by instances of this class. Configure it using <tt>src/main/resources/logback.xml</tt>.
+     */
+    private final static Logger LOGGER = LoggerFactory.getLogger(GeoLocation.class);
+    /**
+     * Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north).
+     */
+    private double latitude;
+    /**
+     * Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     * (east).
+     */
+    private double longitude;
+    /**
+     * Elevation above sea level in meters or null if it could not be calculated.
+     */
+    private Double elevation;
+
+    /**
+     * No argument constructor as required by Apache Flink. Do not use this in your own code.
+     */
+    public GeoLocation() {
+        // Nothing to do here
+    }
+
+    /**
+     * Creates a new completely initialized {@link GeoLocation} with not altitude information.
+     *
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     */
+    public GeoLocation(final double latitude, final double longitude) {
+        this(latitude, longitude, null);
+    }
+
+    /**
+     * Creates a new completely initialized {@link GeoLocation} with altitude information.
+     *
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     * @param elevation the elevation above sea level in meters or null if it could not be calculated
+     */
+    public GeoLocation(final double latitude, final double longitude, final Double elevation) {
+        setLatitude(latitude);
+        setLongitude(longitude);
+        this.elevation = elevation;
+    }
+
+    /**
+     * Calculates the distance from this geo-locations to another one based on their latitude and longitude. This simple
+     * formula assumes the earth is a perfect sphere. As the earth is a spheroid instead, the result can be inaccurate,
+     * especially for longer distances.
+     * <p>
+     * Source: https://stackoverflow.com/a/27943/5815054
+     *
+     * @param location The location to calculate the distance to
+     * @return the estimated distance between both locations in kilometers
+     */
+    public double distanceTo(final GeoLocation location) {
+        final int earthRadiusKm = 6371;
+        final double latitudeDifferenceRad = degreeToRad(location.getLatitude() - getLatitude());
+        final double longitudeDifferenceRad = degreeToRad(location.getLongitude() - getLongitude());
+        final double a = Math.sin(latitudeDifferenceRad / 2) * Math.sin(latitudeDifferenceRad / 2) +
+                Math.cos(degreeToRad(getLatitude())) * Math.cos(degreeToRad(location.getLatitude())) *
+                        Math.sin(longitudeDifferenceRad / 2) * Math.sin(longitudeDifferenceRad / 2);
+        final double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return earthRadiusKm * c;
+    }
+
+    /**
+     * Converts a degree value to the "rad" unit.
+     * <p>
+     * Source: https://stackoverflow.com/a/27943/5815054
+     *
+     * @param degree the value to be converted in the degree unit
+     * @return the value in the rad unit
+     */
+    private double degreeToRad(final double degree) {
+        return degree * (Math.PI / 180);
+    }
+
+    @Override
+    public String toString() {
+        return "GeoLocation{" + "latitude=" + latitude + ", longitude=" + longitude + ", elevation=" + elevation + '}';
+    }
+
+    /**
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     */
+    public final void setLongitude(final double longitude) {
+        if (longitude < -180.0 || longitude > 180.0) {
+            // We may only warn here, since some smartphone manufacturers seem to have a strange definition of geo
+            // coordinates.
+            LOGGER.warn("Setting longitude to invalid value: {}", longitude);
+        }
+        this.longitude = longitude;
+    }
+
+    /**
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     */
+    public final void setLatitude(final double latitude) {
+        if (latitude < -90.0 || latitude > 90.0) {
+            // We may only warn here, since some smartphone manufacturers seem to have a strange definition of geo
+            // coordinates.
+            LOGGER.warn("Setting latitude to invalid value: {}", latitude);
+        }
+        this.latitude = latitude;
+    }
+
+    /**
+     * @param elevation the elevation above sea level in meters or null if it could not be calculated
+     */
+    public final void setElevation(final Double elevation) {
+        this.elevation = elevation;
+    }
+
+    /**
+     * @return Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     */
+    public double getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * @return Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *         (east)
+     */
+    public double getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * @return the elevation above sea level in meters or null if it could not be calculated
+     */
+    public Double getElevation() {
+        return elevation;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((elevation == null) ? 0 : elevation.hashCode());
+        long temp;
+        temp = Double.doubleToLongBits(latitude);
+        result = prime * result + (int)(temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(longitude);
+        result = prime * result + (int)(temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        GeoLocation other = (GeoLocation)obj;
+        if (elevation == null) {
+            if (other.elevation != null) {
+                return false;
+            }
+        } else if (!elevation.equals(other.elevation)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(latitude) != Double.doubleToLongBits(other.latitude)) {
+            return false;
+        }
+        return Double.doubleToLongBits(longitude) == Double.doubleToLongBits(other.longitude);
+    }
+
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/GeoLocationRecord.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/GeoLocationRecord.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * A model POJO representing the recording of a {@link GeoLocation}.
+ *
+ * @author Klemens Muthmann
+ * @version 1.1.1
+ * @since 2.0.0
+ */
+public abstract class GeoLocationRecord extends GeoLocation implements DataPoint {
+    /**
+     * The world wide unique identifier of the measurement, this {@link GeoLocationRecord} belongs to.
+     */
+    private MeasurementIdentifier measurementIdentifier;
+    /**
+     * The timestamp this location was captured on in milliseconds since 1st January 1970 (epoch)
+     */
+    private long timestamp;
+
+    /**
+     * No argument constructor as required by Apache Flink. Do NOT use this in your own code.
+     */
+    public GeoLocationRecord() {
+        // Nothing to do here.
+    }
+
+    /**
+     * Creates a new completely initialized object of this class.
+     *
+     * @param measurementIdentifier The world wide unique identifier of the measurement, this
+     *            {@link GeoLocationRecord}
+     *            belongs to
+     * @param timestamp The timestamp this location was captured on in milliseconds since 1st January 1970 (epoch)
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     */
+    public GeoLocationRecord(final MeasurementIdentifier measurementIdentifier, final long timestamp,
+                             final double latitude, final double longitude) {
+        this(measurementIdentifier, timestamp, latitude, longitude, null);
+    }
+
+    /**
+     * Creates a new completely initialized object of this class.
+     *
+     * @param measurementIdentifier The world wide unique identifier of the measurement, this {@link GeoLocationRecord}
+     *            belongs to
+     * @param timestamp The timestamp this location was captured on in milliseconds since 1st January 1970 (epoch)
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     * @param elevation The elevation above sea level in meters or <code>null</code> if it could not be calculated
+     */
+    public GeoLocationRecord(final MeasurementIdentifier measurementIdentifier, final long timestamp,
+                             final double latitude, final double longitude, final Double elevation) {
+        super(latitude, longitude, elevation);
+        setTimestamp(timestamp);
+        setMeasurementIdentifier(measurementIdentifier);
+    }
+
+    /**
+     * @return The world wide unique identifier of the measurement, this {@link GeoLocationRecord} belongs to.
+     */
+    public final MeasurementIdentifier getMeasurementIdentifier() {
+        return measurementIdentifier;
+    }
+
+    /**
+     * @param measurementIdentifier The world wide unique identifier of the measurement, this
+     *            {@link GeoLocationRecord}
+     *            belongs to.
+     */
+    public final void setMeasurementIdentifier(final MeasurementIdentifier measurementIdentifier) {
+        this.measurementIdentifier = measurementIdentifier;
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void setTimestamp(long timestamp) {
+        Validate.isTrue(timestamp > 0L);
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public int compareTo(final DataPoint that) {
+        return Long.compare(this.timestamp, that.getTimestamp());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+        GeoLocationRecord that = (GeoLocationRecord)o;
+        return timestamp == that.timestamp && Objects.equals(measurementIdentifier, that.measurementIdentifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), measurementIdentifier, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "GeoLocationRecord{" +
+                "measurementIdentifier=" + measurementIdentifier +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/Measurement.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/Measurement.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A single measurement captured by a Cyface measurement device.
+ * <p>
+ * Even though this object has setters for all fields and a no argument constructor, it should be handled as immutable.
+ * The reason for the existence of those setters and the constructor is the requirement to use objects of this class as
+ * part of Apache Flink Pipelines, which require public setters and a no argument constructor to transfer objects
+ * between cluster nodes.
+ *
+ * @author Armin Schnabel
+ * @author Klemens Muthmann
+ */
+public class Measurement {
+    /**
+     * The logger used by objects of this class. Configure it using <tt>src/main/resources/logback.xml</tt>.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Measurement.class);
+    /**
+     * The context of this {@code Measurement}.
+     */
+    private MetaData metaData;
+    /**
+     * The data collected for this {@code Measurement} in {@code Track}-slices, ordered by timestamp.
+     */
+    private List<Track> tracks;
+
+    /**
+     * Creates a new uninitialized {@code Measurement}. This is only necessary for Flink serialisation and should never
+     * be called from your own code.
+     */
+    public Measurement() {
+        this.tracks = Collections.emptyList();
+        // Nothing to do here.
+    }
+
+    /**
+     * Creates a new completely initialized {@code Measurement}.
+     *
+     * @param metaData The context of this {@code Measurement}.
+     * @param tracks The data collected for this {@code Measurement} in {@code Track}-slices, ordered by timestamp.
+     */
+    public Measurement(final MetaData metaData, final List<Track> tracks) {
+        Validate.notNull(metaData);
+
+        this.metaData = metaData;
+        this.tracks = new ArrayList<>(tracks);
+    }
+
+    /**
+     * @return The context of this {@code Measurement}.
+     */
+    public MetaData getMetaData() {
+        return metaData;
+    }
+
+    /**
+     * @return The data collected for this {@code Measurement} in {@code Track}-slices, ordered by timestamp.
+     */
+    public List<Track> getTracks() {
+        return List.copyOf(tracks);
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param metaData The context of this {@code Measurement}.
+     */
+    public void setMetaData(final MetaData metaData) {
+        this.metaData = metaData;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param tracks The data collected for this {@code Measurement} in {@code Track}-slices, ordered by timestamp.
+     */
+    public void setTracks(final List<Track> tracks) {
+        this.tracks = new ArrayList<>(tracks);
+    }
+
+    /**
+     * Exports this measurement as a CSV file.
+     *
+     * @param handler A handler that gets one line of CSV output per call
+     * @param withCsvHeader {@code True} if a CSV header should be added before the data
+     */
+    public void asCsv(final boolean withCsvHeader, final Consumer<String> handler) {
+        if (withCsvHeader) {
+            csvHeader(handler);
+        }
+
+        Modality lastModality = Modality.UNKNOWN;
+
+        // Iterate through tracks
+        var modalityTypeDistance = 0.0;
+        var totalDistance = 0.0;
+        var modalityTypeTravelTime = 0L;
+        var totalTravelTime = 0L;
+        for (var i = 0; i < tracks.size(); i++) {
+            final var trackId = i + 1; // the data receiver probably counts from 1 on not from 0
+            final var track = tracks.get(i);
+
+            // Iterate through locations
+            RawRecord lastLocation = null;
+            for (final var locationRecord : track.getLocationRecords()) {
+                if (lastLocation != null) {
+                    final var newDistance = lastLocation.distanceTo(locationRecord);
+                    modalityTypeDistance += newDistance;
+                    totalDistance += newDistance;
+                    final var timeTraveled = locationRecord.getTimestamp()
+                            - lastLocation.getTimestamp();
+                    modalityTypeTravelTime += timeTraveled;
+                    totalTravelTime += timeTraveled;
+                }
+
+                // Check if the modalityType changed
+                if (locationRecord.getModality() != null && locationRecord.getModality() != lastModality) {
+                    lastModality = locationRecord.getModality();
+                    modalityTypeDistance = 0.0;
+                    modalityTypeTravelTime = 0L;
+                }
+
+                handler.accept(csvRow(getMetaData(), locationRecord, trackId,
+                        modalityTypeDistance, totalDistance,
+                        modalityTypeTravelTime, totalTravelTime));
+
+                lastLocation = locationRecord;
+            }
+        }
+    }
+
+    /**
+     * Exports this measurement as GeoJSON feature.
+     *
+     * @param handler A handler that gets the GeoJson feature as string
+     */
+    public void asGeoJson(final Consumer<String> handler) {
+        // We decided to generate a String instead of using a JSON library to avoid dependencies in the model library
+
+        // measurement = geoJson "feature"
+        handler.accept("{");
+        handler.accept(jsonKeyValue("type", "Feature").stringValue);
+        handler.accept(",");
+
+        // All tracks = geometry (MultiLineString)
+        handler.accept("\"geometry\":{");
+        handler.accept(jsonKeyValue("type", "MultiLineString").stringValue);
+        handler.accept(",");
+        handler.accept("\"coordinates\":");
+        final var tracksCoordinates = convertToLineStringCoordinates(getTracks());
+        handler.accept(tracksCoordinates);
+        handler.accept("},");
+
+        final var deviceId = jsonKeyValue("deviceId", getMetaData().getIdentifier().getDeviceIdentifier());
+        final var measurementId = jsonKeyValue("measurementId",
+                getMetaData().getIdentifier().getMeasurementIdentifier());
+        final var length = jsonKeyValue("length", getMetaData().getLength());
+        final var properties = jsonObject(deviceId, measurementId, length);
+        handler.accept(jsonKeyValue("properties", properties).stringValue);
+
+        handler.accept("}");
+    }
+
+    /**
+     * Exports this measurement as Json <b>without sensor data</b>.
+     *
+     * @param handler A handler that gets the Json as string
+     */
+    public void asJson(final Consumer<String> handler) {
+        // We decided to generate a String instead of using a JSON library to avoid dependencies in the model library
+        handler.accept("{");
+
+        handler.accept(jsonKeyValue("metaData", asJson(metaData)).stringValue);
+        handler.accept(",");
+
+        handler.accept("\"tracks\":[");
+        tracks.forEach(track -> handler.accept(featureCollection(track).stringValue));
+        handler.accept("]");
+
+        handler.accept("}");
+    }
+
+    private JsonObject asJson(final MetaData metaData) {
+        return jsonObject(jsonKeyValue("username", metaData.getUsername()),
+                jsonKeyValue("deviceId", metaData.getIdentifier().getDeviceIdentifier()),
+                jsonKeyValue("measurementId", metaData.getIdentifier().getMeasurementIdentifier()),
+                jsonKeyValue("length", metaData.getLength()));
+    }
+
+    /**
+     * Converts a {@link Track} to a {@code GeoJson} "FeatureCollection" with "Point" "Features".
+     *
+     * @param track the {@code Track} to convert
+     * @return the converted {@code Track}
+     */
+    private JsonObject featureCollection(final Track track) {
+        final var points = geoJsonPointFeatures(track.getLocationRecords());
+        final var type = jsonKeyValue("type", "FeatureCollection");
+        final var features = jsonKeyValue("features", points);
+        return jsonObject(type, features);
+    }
+
+    private JsonArray geoJsonPointFeatures(final List<RawRecord> list) {
+        return jsonArray(list.stream().map(l -> geoJsonPointFeature(l).stringValue).toArray(String[]::new));
+    }
+
+    private JsonObject geoJsonPointFeature(final RawRecord record) {
+        final var type = jsonKeyValue("type", "Feature");
+
+        final var geometryType = jsonKeyValue("type", "Point");
+        final var lat = String.valueOf(record.getLatitude());
+        final var lon = String.valueOf(record.getLongitude());
+        final var coordinates = jsonKeyValue("coordinates", jsonArray(lon, lat));
+        final var geometry = jsonKeyValue("geometry", jsonObject(geometryType, coordinates));
+
+        final var timestamp = jsonKeyValue("timestamp", record.getTimestamp());
+        final var speed = jsonKeyValue("speed", record.getSpeed());
+        final var accuracy = jsonKeyValue("accuracy", record.getAccuracy());
+        final var modality = jsonKeyValue("modality", record.getModality().getDatabaseIdentifier());
+        final var properties = jsonKeyValue("properties", jsonObject(timestamp, speed, accuracy, modality));
+
+        return jsonObject(type, geometry, properties);
+    }
+
+    private JsonArray jsonArray(final String... objects) {
+        final var builder = new StringBuilder("[");
+        Arrays.stream(objects).forEach(p -> builder.append(p).append(","));
+        builder.deleteCharAt(builder.length() - 1); // remove trailing comma
+        builder.append("]");
+        return new JsonArray(builder.toString());
+    }
+
+    private JsonObject jsonObject(final KeyValuePair... keyValuePairs) {
+        final var builder = new StringBuilder("{");
+        Arrays.stream(keyValuePairs).forEach(p -> builder.append(p.stringValue).append(","));
+        builder.deleteCharAt(builder.length() - 1); // remove trailing comma
+        builder.append("}");
+        return new JsonObject(builder.toString());
+    }
+
+    private KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key, final JsonArray value) {
+        return new KeyValuePair("\"" + key + "\":" + value.stringValue);
+    }
+
+    private KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key,
+                                      final JsonObject value) {
+        return new KeyValuePair("\"" + key + "\":" + value.stringValue);
+    }
+
+    private KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key, final long value) {
+        return new KeyValuePair("\"" + key + "\":" + value);
+    }
+
+    private KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key, final double value) {
+        return new KeyValuePair("\"" + key + "\":" + value);
+    }
+
+    private KeyValuePair jsonKeyValue(final String key, final String value) {
+        return new KeyValuePair("\"" + key + "\":\"" + value + "\"");
+    }
+
+    /**
+     * Clears the data within this measurement starting at the provided <code>timestamp</code> in milliseconds since the
+     * 01.01.1970 (UNIX Epoch).
+     * <p>
+     * This call modifies the called measurement.
+     *
+     * @param timestamp The timestamp in milliseconds since the first of January 1970 to begin clearing the data at
+     * @return This cleared <code>Measurement</code>
+     * @throws TimestampNotFound If the timestamp is not within the timeframe of this measurement
+     */
+    public Measurement clearAfter(final long timestamp) throws TimestampNotFound {
+        final var trackIndex = getIndexOfTrackContaining(timestamp);
+        while (tracks.size() - 1 > trackIndex) {
+            tracks.remove(tracks.size() - 1);
+        }
+        tracks.get(trackIndex).clearAfter(timestamp);
+        return this;
+    }
+
+    /**
+     * Tries to find the track from this measurement containing the provided timestamp.
+     *
+     * @param timestamp A timestamp in milliseconds since the first of January 1970
+     * @return The index of the track containing the provided timestamp
+     * @throws TimestampNotFound If the timestamp is not within the timeframe of this measurement
+     */
+    private int getIndexOfTrackContaining(final long timestamp) throws TimestampNotFound {
+        LOGGER.trace("Getting track index for timestamp: {} ({})!",
+                SimpleDateFormat.getDateTimeInstance().format(new Date(timestamp)), timestamp);
+        for (var i = 0; i < tracks.size(); i++) {
+            var track = tracks.get(i);
+            var minRotationsTimestamp = track.getRotations().isEmpty() ? Long.MAX_VALUE
+                    : track.getRotations().get(0).getTimestamp();
+            var minDirectionsTimestamp = track.getDirections().isEmpty() ? Long.MAX_VALUE
+                    : track.getDirections().get(0).getTimestamp();
+            var minAccelerationsTimestamp = track.getAccelerations().isEmpty() ? Long.MAX_VALUE
+                    : track.getAccelerations().get(0).getTimestamp();
+            var minLocationsTimestamp = track.getLocationRecords().isEmpty() ? Long.MAX_VALUE
+                    : track.getLocationRecords().get(0).getTimestamp();
+            var minTrackTimestamp = Math.min(minRotationsTimestamp,
+                    Math.min(minDirectionsTimestamp, Math.min(minAccelerationsTimestamp, minLocationsTimestamp)));
+            Validate.isTrue(minTrackTimestamp < Long.MAX_VALUE);
+
+            var maxRotationsTimestamp = track.getRotations().isEmpty() ? Long.MIN_VALUE
+                    : track.getRotations().get(track.getRotations().size() - 1).getTimestamp();
+            var maxDirectionsTimestamp = track.getDirections().isEmpty() ? Long.MIN_VALUE
+                    : track.getDirections().get(track.getDirections().size() - 1).getTimestamp();
+            var maxAccelerationsTimestamp = track.getAccelerations().isEmpty() ? Long.MIN_VALUE
+                    : track.getAccelerations().get(track.getAccelerations().size() - 1).getTimestamp();
+            var maxLocationsTimestamp = track.getLocationRecords().isEmpty() ? Long.MIN_VALUE
+                    : track.getLocationRecords().get(track.getLocationRecords().size() - 1).getTimestamp();
+            var maxTrackTimestamp = Math.max(maxRotationsTimestamp,
+                    Math.max(maxDirectionsTimestamp, Math.max(maxAccelerationsTimestamp, maxLocationsTimestamp)));
+            Validate.isTrue(maxTrackTimestamp > Long.MIN_VALUE);
+
+            LOGGER.trace("Min timestamp for index {} is {} ({}).", i,
+                    SimpleDateFormat.getDateTimeInstance().format(new Date(minTrackTimestamp)), minTrackTimestamp);
+            LOGGER.trace("Max timestamp for index {} is {} ({}).", i,
+                    SimpleDateFormat.getDateTimeInstance().format(new Date(maxTrackTimestamp)), maxTrackTimestamp);
+            if (timestamp >= minTrackTimestamp && timestamp <= maxTrackTimestamp) {
+                LOGGER.trace("Selected index {}.", i);
+                return i;
+            }
+        }
+        throw new TimestampNotFound(String.format("Unable to find track index for timestamp %s (%s) in measurement %s!",
+                SimpleDateFormat.getDateTimeInstance().format(new Date(timestamp)), timestamp,
+                getMetaData()));
+    }
+
+    /**
+     * Creates a CSV header for this measurement.
+     *
+     * @param handler The handler that is notified of the new CSV row.
+     */
+    public static void csvHeader(final Consumer<String> handler) {
+        final var csvHeaderRow = String.join(",", "username", "deviceId",
+                "measurementId",
+                "trackId",
+                "timestamp [ms]", "latitude", "longitude", "speed [m/s]",
+                "accuracy [m]",
+                "modalityType", "modalityTypeDistance [km]", "distance [km]",
+                "modalityTypeTravelTime [ms]", "travelTime [ms]");
+        handler.accept(csvHeaderRow);
+    }
+
+    /**
+     * Converts one location entry annotated with meta data to a CSV row.
+     *
+     * @param metaData the {@code Measurement} of the {@param location}
+     * @param locationRecord the {@code GeoLocationRecord} to be processed
+     * @param trackId the id of the sub track starting at 1
+     * @param modalityTypeDistance the distance traveled so far with this {@param modality} type
+     * @param totalDistance the total distance traveled so far
+     * @param modalityTypeTravelTime the time traveled so far with this {@param modality} type
+     * @param totalTravelTime the time traveled so far
+     * @return the csv row as String
+     */
+    private String csvRow(final MetaData metaData, final RawRecord locationRecord, final int trackId,
+                          final double modalityTypeDistance, final double totalDistance,
+                          final long modalityTypeTravelTime, final long totalTravelTime) {
+        final var username = metaData.getUsername();
+        final var deviceId = metaData.getIdentifier().getDeviceIdentifier();
+        final var measurementId = String.valueOf(metaData.getIdentifier().getMeasurementIdentifier());
+        return String.join(",", username, deviceId, measurementId, String.valueOf(trackId),
+                String.valueOf(locationRecord.getTimestamp()),
+                String.valueOf(locationRecord.getLatitude()),
+                String.valueOf(locationRecord.getLongitude()), String.valueOf(locationRecord.getSpeed()),
+                String.valueOf(locationRecord.getAccuracy()),
+                locationRecord.getModality().getDatabaseIdentifier(),
+                String.valueOf(modalityTypeDistance), String.valueOf(totalDistance),
+                String.valueOf(modalityTypeTravelTime), String.valueOf(totalTravelTime));
+    }
+
+    /**
+     * Converts a single track to geoJson "coordinates".
+     *
+     * @param tracks the {@code Track}s to be processed
+     * @return the string representation of the geoJson coordinates
+     */
+    private String convertToLineStringCoordinates(final List<Track> tracks) {
+        final var builder = new StringBuilder("[");
+
+        // Each track is a LineString
+        tracks.forEach(track -> {
+            final var points = jsonArray(
+                    track.getLocationRecords().stream().map(l -> geoJsonCoordinates(l).stringValue)
+                            .toArray(String[]::new));
+            builder.append(points.stringValue);
+            builder.append(",");
+        });
+        builder.deleteCharAt(builder.length() - 1); // delete last ","
+        builder.append("]");
+
+        return builder.toString();
+    }
+
+    private JsonArray geoJsonCoordinates(final RawRecord record) {
+        return jsonArray(String.valueOf(record.getLongitude()), String.valueOf(record.getLatitude()));
+    }
+
+    @Override
+    public String toString() {
+        return "Measurement{" +
+                "metaData=" + metaData +
+                ", tracks=" + tracks +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final var that = (Measurement)o;
+        return metaData.equals(that.metaData) &&
+                tracks.equals(that.tracks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metaData, tracks);
+    }
+
+    private static class KeyValuePair {
+        private final String stringValue;
+
+        public KeyValuePair(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        public String getStringValue() {
+            return stringValue;
+        }
+    }
+
+    private static class JsonObject {
+        private final String stringValue;
+
+        public JsonObject(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        public String getStringValue() {
+            return stringValue;
+        }
+    }
+
+    private static class JsonArray {
+        private final String stringValue;
+
+        public JsonArray(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        public String getStringValue() {
+            return stringValue;
+        }
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/MeasurementIdentifier.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/MeasurementIdentifier.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) Cyface GmbH - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Klemens Muthmann <klemens.muthmann@cyface.de>, June 2019
+ */
+package de.cyface.model.v1;
+
+import org.apache.commons.lang3.Validate;
+
+import java.io.Serializable;
+
+/**
+ * Describes the world wide unique identifier of a measurement. This identifier consists of a device identifier and the
+ * actual measurement from that device.
+ * <p>
+ * The natural order of <code>MeasurementIdentifier</code> is lexicographically by device identifier and then by
+ * measurement identifier.
+ *
+ * @author Klemens Muthmann
+ * @version 1.0.0
+ * @since 2.0.0
+ */
+public final class MeasurementIdentifier implements Comparable<MeasurementIdentifier>, Serializable {
+
+
+    private static final long serialVersionUID = 181303400330020850L;
+    /**
+     * The world wide unique identifier of the device that captured this measurement.
+     */
+    private String deviceIdentifier;
+    /**
+     * The device wide unique identifier of the measurement.
+     */
+    private long measurementIdentifier;
+
+    /**
+     * The default no arguments constructor as required by Apache Flink to serialize and deserialize objects of this
+     * class. Do not use this in you own code, it creates an unusable <code>MeasurementIdentifier</code>.
+     */
+    public MeasurementIdentifier() {
+        // Nothing to do here.
+    }
+
+    /**
+     * Creates a new completely initialized object of this class.
+     *
+     * @param deviceIdentifier The world wide unique identifier of the device that captured this measurement
+     * @param measurementIdentifier The device wide unique identifier of the measurement
+     */
+    public MeasurementIdentifier(final String deviceIdentifier, final long measurementIdentifier) {
+        setDeviceIdentifier(deviceIdentifier);
+        setMeasurementIdentifier(measurementIdentifier);
+    }
+
+    /**
+     * @return The world wide unique identifier of the device that captured this measurement
+     */
+    public String getDeviceIdentifier() {
+        return deviceIdentifier;
+    }
+
+    /**
+     * @return The device wide unique identifier of the measurement
+     */
+    public long getMeasurementIdentifier() {
+        return measurementIdentifier;
+    }
+
+    /**
+     * @param deviceIdentifier The world wide unique identifier of the device that captured this measurement
+     */
+    public void setDeviceIdentifier(final String deviceIdentifier) {
+        Validate.notEmpty(deviceIdentifier);
+
+        this.deviceIdentifier = deviceIdentifier;
+    }
+
+    /**
+     * @param measurementIdentifier The device wide unique identifier of the measurement
+     */
+    public void setMeasurementIdentifier(final long measurementIdentifier) {
+        Validate.isTrue(measurementIdentifier >= 0);
+
+        this.measurementIdentifier = measurementIdentifier;
+    }
+
+    @Override
+    public int hashCode() {
+        final var prime = 31;
+        int result = 1;
+        result = prime * result + ((deviceIdentifier == null) ? 0 : deviceIdentifier.hashCode());
+        result = prime * result + (int)(measurementIdentifier ^ (measurementIdentifier >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MeasurementIdentifier [deviceIdentifier=" + deviceIdentifier + ", measurementIdentifier="
+                + measurementIdentifier + "]";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        var other = (MeasurementIdentifier)obj;
+        if (deviceIdentifier == null) {
+            if (other.deviceIdentifier != null)
+                return false;
+        } else if (!deviceIdentifier.equals(other.deviceIdentifier))
+            return false;
+        return measurementIdentifier == other.measurementIdentifier;
+    }
+
+    @Override
+    public int compareTo(final MeasurementIdentifier measurementIdentifier) {
+        final var deviceIdentifierComparison = this.getDeviceIdentifier()
+                .compareTo(measurementIdentifier.getDeviceIdentifier());
+        return deviceIdentifierComparison == 0
+                ? Long.compare(this.getMeasurementIdentifier(), measurementIdentifier.getMeasurementIdentifier())
+                : deviceIdentifierComparison;
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/MetaData.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/MetaData.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2020-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import org.apache.commons.lang3.Validate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The context of a {@code Measurement}.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 1.2.0
+ */
+public class MetaData implements Serializable {
+
+    /**
+     * The version of the deserialized measurement model.
+     * <p>
+     * Required to read measurement documents from the database which were deserialized by different deserializers.
+     */
+    public static final String CURRENT_VERSION = "1.0.0";
+    /**
+     * Regex of supported {@link MetaData} versions of this class.
+     */
+    public static final String SUPPORTED_VERSIONS = "1.0.0";
+    /**
+     * Used to serialize objects of this class. Only change this value if this classes attribute set changes.
+     */
+    private static final long serialVersionUID = -1392990537941531856L;
+    /**
+     * The worldwide unique identifier of the measurement.
+     */
+    private MeasurementIdentifier identifier;
+    /**
+     * The type of device uploading the data, such as "Pixel 3" or "iPhone 6 Plus".
+     */
+    private String deviceType;
+    /**
+     * The operating system version, such as "Android 9.0.0" or "iOS 11.2".
+     */
+    private String osVersion;
+    /**
+     * The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
+     */
+    private String appVersion;
+    /**
+     * The length of the measurement in meters.
+     */
+    private double length;
+    /**
+     * The name of the user who has uploaded this measurement.
+     */
+    private String username;
+    /**
+     * The version of the {@code Measurement} model in the deserialized format, such as "1.1.1" or "2.0.0".
+     */
+    private String version;
+
+    /**
+     * Creates new completely initialized <code>MetaData</code>.
+     *
+     * @param identifier The worldwide unique identifier of the measurement.
+     * @param deviceType The type of device uploading the data, such as "Pixel 3" or "iPhone 6 Plus".
+     * @param osVersion The operating system version, such as "Android 9.0.0" or "iOS 11.2".
+     * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
+     * @param length The length of the measurement in meters.
+     * @param username The name of the user who has uploaded this measurement.
+     * @param version The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
+     */
+    public MetaData(final MeasurementIdentifier identifier, final String deviceType, final String osVersion,
+                    final String appVersion, final double length, final String username, final String version) {
+
+        Validate.isTrue(version.matches(SUPPORTED_VERSIONS), "Unsupported version: %s", version);
+        this.identifier = identifier;
+        this.deviceType = deviceType;
+        this.osVersion = osVersion;
+        this.appVersion = appVersion;
+        this.length = length;
+        this.username = username;
+        this.version = version;
+    }
+
+    /**
+     * No argument constructor as required by Apache Flink. Do not use this in your own code.
+     */
+    @SuppressWarnings("unused")
+    public MetaData() {
+        // Nothing to do
+    }
+
+    /**
+     * @return The worldwide unique identifier of the measurement.
+     */
+    public MeasurementIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * @return The type of device uploading the data, such as "Pixel 3" or "iPhone 6 Plus".
+     */
+    public String getDeviceType() {
+        return deviceType;
+    }
+
+    /**
+     * @return The operating system version, such as "Android 9.0.0" or "iOS 11.2".
+     */
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    /**
+     * @return The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
+     */
+    public String getAppVersion() {
+        return appVersion;
+    }
+
+    /**
+     * @return The length of the measurement in meters.
+     */
+    public double getLength() {
+        return length;
+    }
+
+    /**
+     * @return The name of the user who has uploaded this measurement.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @return The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param identifier The worldwide unique identifier of the measurement.
+     */
+    public void setIdentifier(final MeasurementIdentifier identifier) {
+        this.identifier = identifier;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param deviceType The type of device uploading the data, such as "Pixel 3" or "iPhone 6 Plus".
+     */
+    @SuppressWarnings("unused")
+    public void setDeviceType(final String deviceType) {
+        this.deviceType = deviceType;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param osVersion The operating system version, such as "Android 9.0.0" or "iOS 11.2".
+     */
+    @SuppressWarnings("unused")
+    public void setOsVersion(final String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
+     */
+    @SuppressWarnings("unused")
+    public void setAppVersion(final String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param length The length of the measurement in meters.
+     */
+    @SuppressWarnings("unused")
+    public void setLength(final double length) {
+        this.length = length;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param username The name of the user who has uploaded this measurement.
+     */
+    @SuppressWarnings("unused")
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param version The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
+     */
+    public void setVersion(final String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "MetaData{" +
+                "identifier=" + identifier +
+                ", deviceType='" + deviceType + '\'' +
+                ", osVersion='" + osVersion + '\'' +
+                ", appVersion='" + appVersion + '\'' +
+                ", length=" + length +
+                ", username='" + username + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MetaData metaData = (MetaData)o;
+        return Double.compare(metaData.length, length) == 0 &&
+                identifier.equals(metaData.identifier) &&
+                deviceType.equals(metaData.deviceType) &&
+                osVersion.equals(metaData.osVersion) &&
+                appVersion.equals(metaData.appVersion) &&
+                username.equals(metaData.username) &&
+                version.equals(metaData.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, deviceType, osVersion, appVersion, length, username, version);
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/Modality.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/Modality.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+/**
+ * The {@link Modality} types to choose from when starting a {@link Measurement}. This class maps the database values to
+ * enum values, to make sure the correct values are used within the Java code.
+ *
+ * @author Armin Schnabel
+ * @author Klemens Muthmann
+ * @version 2.0.0
+ * @since 1.0.0
+ */
+public enum Modality {
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    BICYCLE("BICYCLE"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    CAR("CAR"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    MOTORBIKE("MOTORBIKE"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    BUS("BUS"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    TRAIN("TRAIN"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    WALKING("WALKING"),
+    /**
+     * This is used if a bicycle was used to capture a measurement.
+     */
+    UNKNOWN("UNKNOWN");
+
+    /**
+     * The modality types identifier within the database.
+     */
+    private String databaseIdentifier;
+
+    /**
+     * Creates a new enumeration case for a <code>Modality</code>. This constructor is only used internally and thus not
+     * visible outside of this package.
+     *
+     * @param databaseIdentifier The modality types identifier within the database
+     */
+    Modality(final String databaseIdentifier) {
+        this.databaseIdentifier = databaseIdentifier;
+    }
+
+    /**
+     * @return The modality types identifier within the database
+     */
+    public String getDatabaseIdentifier() {
+        return databaseIdentifier;
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/Point3D.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/Point3D.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * A measured {@code DataPoint} with three coordinates such as an acceleration-, rotation- or magnetic value point.
+ *
+ * @author Klemens Muthmann
+ * @version 4.0.1
+ * @since 1.0.0
+ */
+public final class Point3D implements DataPoint {
+    private long timestamp;
+    /**
+     * The x component of the data point.
+     */
+    private float x;
+    /**
+     * The y component of the data point.
+     */
+    private float y;
+    /**
+     * The z component of the data point.
+     */
+    private float z;
+
+    /**
+     * Default constructor as required by Apache Flink. Do not use this in your own code.
+     */
+    public Point3D() {
+        // Nothing to do here
+    }
+
+    /**
+     * Creates a new completely initialized <code>Point3D</code>.
+     *
+     * @param x The x component of the data point
+     * @param y The y component of the data point
+     * @param z The z component of the data point
+     * @param timestamp The time when this point was measured in milliseconds since 1.1.1970
+     */
+    public Point3D(final float x, final float y, final float z, final long timestamp) {
+        setTimestamp(timestamp);
+        setX(x);
+        setY(y);
+        setZ(z);
+    }
+
+    /**
+     * Creates a new completely initialized <code>Point3D</code> with <code>double</code> coordinates as input.
+     *
+     * @param x The x component of the data point
+     * @param y The y component of the data point
+     * @param z The z component of the data point
+     * @param timestamp The time when this point was measured in milliseconds since 1.1.1970
+     */
+    public Point3D(final double x, final double y, final double z, final long timestamp) {
+        this(Double.valueOf(x).floatValue(), Double.valueOf(y).floatValue(), Double.valueOf(z).floatValue(), timestamp);
+    }
+
+    /**
+     * @return The x component of the data point
+     */
+    public float getX() {
+        return x;
+    }
+
+    /**
+     * @return The y component of the data point
+     */
+    public float getY() {
+        return y;
+    }
+
+    /**
+     * @return The z component of the data point
+     */
+    public float getZ() {
+        return z;
+    }
+
+    /**
+     * @param x The x component of the data point
+     */
+    public void setX(float x) {
+        this.x = x;
+    }
+
+    /**
+     * @param y The y component of the data point
+     */
+    public void setY(float y) {
+        this.y = y;
+    }
+
+    /**
+     * @param z The z component of the data point
+     */
+    public void setZ(float z) {
+        this.z = z;
+    }
+
+    @Override
+    public String toString() {
+        return "Point X: " + x + "Y: " + y + "Z: " + z + " TS: " + getTimestamp();
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void setTimestamp(long timestamp) {
+        Validate.isTrue(timestamp > 0L);
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public int compareTo(final DataPoint that) {
+        return Long.compare(this.timestamp, that.getTimestamp());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Point3D point3D = (Point3D)o;
+        return timestamp == point3D.timestamp && Float.compare(point3D.x, x) == 0 && Float.compare(point3D.y, y) == 0
+                && Float.compare(point3D.z, z) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, x, y, z);
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/RawRecord.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/RawRecord.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import org.apache.commons.lang3.Validate;
+
+public class RawRecord extends GeoLocationRecord {
+    /**
+     * The measurement accuracy of this location in meters. This accuracy is usually the result of imperfect
+     * measurement hardware.
+     */
+    private double accuracy;
+    /**
+     * The traveled speed as reported by the geo location system (e.g. GPS, GLONASS, GALILEO) during this recording.
+     */
+    private double speed;
+    /**
+     * The modality type used while collecting this location or {@code null} if the information is not available.
+     */
+    private Modality modality;
+
+    /**
+     * No-argument constructor as required by Apache Flink. Do not use this in your own code.
+     */
+    public RawRecord() {
+        // Nothing to do here.
+    }
+
+    public RawRecord(final MeasurementIdentifier measurementIdentifier, final long timestamp,
+                     final double latitude, final double longitude, final double accuracy, final double speed, final Modality modality) {
+        super(measurementIdentifier, timestamp, latitude, longitude, null);
+
+        setAccuracy(accuracy);
+        setSpeed(speed);
+        setModality(modality);
+    }
+
+    /**
+     * Creates a new completely initialized <code>RawRecord</code>.
+     *
+     * @param measurementIdentifier The world wide unique identifier of the {@link Measurement} this record belongs to
+     * @param timestamp The timestamp this location was captured on in milliseconds since 1st January 1970 (epoch)
+     * @param latitude Geographical latitude in coordinates (decimal fraction) raging from -90° (south) to 90° (north)
+     * @param longitude Geographical longitude in coordinates (decimal fraction) ranging from -180° (west) to 180°
+     *            (east)
+     * @param elevation The elevation above sea level in meters or null if it could not be calculated
+     * @param accuracy The measurement accuracy of this location in meters. This accuracy is usually the result of
+     *            imperfect measurement hardware
+     * @param speed The traveled speed as reported by the geo location system (e.g. GPS, GLONASS, GALILEO) during this
+     *            recording
+     * @param modality The modality type used while collecting the location or {@code null} if the information is not
+     *            available
+     */
+    public RawRecord(final MeasurementIdentifier measurementIdentifier, final long timestamp,
+                     final double latitude, final double longitude, final Double elevation, final double accuracy,
+                     final double speed, final Modality modality) {
+        super(measurementIdentifier, timestamp, latitude, longitude, elevation);
+
+        setAccuracy(accuracy);
+        setSpeed(speed);
+        setModality(modality);
+    }
+
+    /**
+     * @return The measurement accuracy of this location in meters. This accuracy is usually the result of imperfect
+     *         measurement hardware.
+     */
+    public final double getAccuracy() {
+        return accuracy;
+    }
+
+    /**
+     * @param accuracy The measurement accuracy of this location in meters. This accuracy is usually the result of
+     *            imperfect measurement hardware.
+     */
+    public final void setAccuracy(double accuracy) {
+        Validate.isTrue(accuracy >= 0.0);
+        this.accuracy = accuracy;
+    }
+
+    /**
+     * @return The traveled speed as reported by the geo location system (e.g. GPS, GLONASS, GALILEO) during this
+     *         recording
+     */
+    public double getSpeed() {
+        return speed;
+    }
+
+    /**
+     * @return The modality type used while collecting this location or {@code null} if the information is not
+     *         available.
+     */
+    public Modality getModality() {
+        return modality;
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param accuracy The measurement accuracy of this location in meters. This accuracy is usually the result of
+     *            imperfect measurement hardware.
+     */
+    public void setAccuracy(int accuracy) {
+        this.accuracy = accuracy;
+    }
+
+    /**
+     * @param speed The traveled speed as reported by the geo location system (e.g. GPS, GLONASS, GALILEO) during this
+     *            recording
+     */
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    /**
+     * Required by Apache Flink and to annotate the modality types separately.
+     *
+     * @param modality The modality type used while collecting this location or {@code null} if the information is not
+     *            available.
+     */
+    public void setModality(Modality modality) {
+        this.modality = modality;
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/TimestampNotFound.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/TimestampNotFound.java
@@ -1,0 +1,18 @@
+package de.cyface.model.v1;
+
+/**
+ * An <code>Exception</code> thrown if a timestamp was not within range of a certain time frame.
+ *
+ * @author Klemens Muthmann
+ */
+public class TimestampNotFound extends Exception {
+
+    /**
+     * Creates a new exception with an error message.
+     *
+     * @param message The error message to report
+     */
+    public TimestampNotFound(final String message) {
+        super(message);
+    }
+}

--- a/libs/model/src/main/java/de/cyface/model/v1/Track.java
+++ b/libs/model/src/main/java/de/cyface/model/v1/Track.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2019-2021 Cyface GmbH
+ *
+ * This file is part of the Cyface Data Collector.
+ *
+ * The Cyface Data Collector is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface Data Collector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface Data Collector. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model.v1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A part of a measurement for which continuous data is available and ordered by time.
+ * <p>
+ * A {@code Track} begins with the first {@code GeoLocation} collected after start or resume was triggered during data
+ * collection. It stops with the last collected {@code GeoLocation} before the next resume command was triggered or
+ * when the very last locations is reached.
+ *
+ * @author Armin Schnabel
+ * @version 2.0.0
+ * @since 1.0.0
+ */
+public class Track {
+    /**
+     * The list of {@code GeoLocationRecord}s collected for this {@code Track} ordered by timestamp.
+     */
+    private List<RawRecord> locationRecords;
+    /**
+     * The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     */
+    private List<Point3D> accelerations;
+    /**
+     * The list of rotations for this {@code Track} ordered by timestamp. Unit: rad/s.
+     */
+    private List<Point3D> rotations;
+    /**
+     * The list of directions for this {@code Track} ordered by timestamp. Unit. micro-Tesla (uT).
+     */
+    private List<Point3D> directions;
+
+    /**
+     * Creates a new completely initialized {@code Track}.
+     *
+     * @param locationRecords The list of {@code RawRecord}s collected for this {@code Track} ordered by
+     *            timestamp.
+     * @param accelerations The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     * @param rotations The list of rotations for this {@code Track} ordered by timestamp. Unit: rad/s.
+     * @param directions The list of directions for this {@code Track} ordered by timestamp. Unit. micro-Tesla (uT).
+     */
+    public Track(final List<RawRecord> locationRecords, final List<Point3D> accelerations,
+                 final List<Point3D> rotations, final List<Point3D> directions) {
+        Objects.requireNonNull(locationRecords);
+        Objects.requireNonNull(accelerations);
+        Objects.requireNonNull(rotations);
+        Objects.requireNonNull(directions);
+
+        this.locationRecords = new ArrayList<>(locationRecords);
+        this.accelerations = new ArrayList<>(accelerations);
+        this.rotations = new ArrayList<>(rotations);
+        this.directions = new ArrayList<>(directions);
+    }
+
+    /**
+     * No argument constructor as required by Apache Flink. Do not use this in your own code.
+     */
+    public Track() {
+        // Nothing to do
+    }
+
+    /**
+     * @return The list of {@code GeoLocationRecord}s collected for this {@code Track} ordered by timestamp.
+     */
+    public List<RawRecord> getLocationRecords() {
+        return Collections.unmodifiableList(locationRecords);
+    }
+
+    /**
+     * @return The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     */
+    public List<Point3D> getAccelerations() {
+        return Collections.unmodifiableList(accelerations);
+    }
+
+    /**
+     * @return The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     */
+    public List<Point3D> getRotations() {
+        return Collections.unmodifiableList(rotations);
+    }
+
+    /**
+     * @return The list of directions for this {@code Track} ordered by timestamp. Unit. micro-Tesla (uT).
+     */
+    public List<Point3D> getDirections() {
+        return Collections.unmodifiableList(directions);
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param locationRecords The list of {@code GeoLocationRecord}s collected for this {@code Track} ordered by
+     *            timestamp.
+     */
+    public void setLocationRecords(final List<RawRecord> locationRecords) {
+        Objects.requireNonNull(locationRecords);
+
+        this.locationRecords = new ArrayList<>(locationRecords);
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param accelerations The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     */
+    public void setAccelerations(final List<Point3D> accelerations) {
+        Objects.requireNonNull(locationRecords);
+
+        this.accelerations = new ArrayList<>(accelerations);
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param rotations The list of accelerations for this {@code Track} ordered by timestamp. Unit: m/s².
+     */
+    public void setRotations(final List<Point3D> rotations) {
+        Objects.requireNonNull(locationRecords);
+
+        this.rotations = new ArrayList<>(rotations);
+    }
+
+    /**
+     * Required by Apache Flink.
+     *
+     * @param directions The list of directions for this {@code Track} ordered by timestamp. Unit. micro-Tesla (uT).
+     */
+    public void setDirections(final List<Point3D> directions) {
+        Objects.requireNonNull(locationRecords);
+
+        this.directions = new ArrayList<>(directions);
+    }
+
+    /**
+     * Removes all data after the provided <code>timestamp</code> from this <code>Track</code>.
+     *
+     * @param timestamp A UNIX timestamp in milliseconds since the first of January 1970
+     * @return This track for method chaining
+     */
+    public Track clearAfter(final long timestamp) {
+        locationRecords = locationRecords.stream().filter(record -> record.getTimestamp() >= timestamp)
+                .collect(Collectors.toList());
+        accelerations = accelerations.stream().filter(acceleration -> acceleration.getTimestamp() > timestamp)
+                .collect(Collectors.toList());
+        rotations = rotations.stream().filter(rotation -> rotation.getTimestamp() > timestamp)
+                .collect(Collectors.toList());
+        directions = directions.stream().filter(direction -> direction.getTimestamp() > timestamp)
+                .collect(Collectors.toList());
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Track{" +
+                "geoLocations=" + locationRecords +
+                ", accelerations=" + accelerations +
+                ", rotations=" + rotations +
+                ", directions=" + directions +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Track track = (Track)o;
+        return locationRecords.equals(track.locationRecords) &&
+                accelerations.equals(track.accelerations) &&
+                rotations.equals(track.rotations) &&
+                directions.equals(track.directions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(locationRecords, accelerations, rotations, directions);
+    }
+}

--- a/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
+++ b/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
@@ -25,12 +25,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.Validate;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for the functionality provided directly by the {@link Measurement} class.
@@ -232,6 +242,135 @@ public class MeasurementTest {
     }
 
     /**
+     * Ensures track buckets are sorted before they are composed to a Track.
+     */
+    @Test
+    void testTracks_toSortBuckets() throws ParseException {
+
+        // Arrange
+        final var buckets = generateTrackBuckets(0, 2, Modality.BICYCLE);
+
+        // Un-sort track buckets
+        buckets.sort(Comparator.comparing(TrackBucket::getBucket).reversed());
+
+        // Act
+        final var oocut = new Measurement(buckets);
+
+        // Assert
+        final var expectedTrack = generateMeasurement( 1, new Modality[] {Modality.BICYCLE}).getTracks().get(0);
+        assertThat(oocut.getTracks().size(), CoreMatchers.is(CoreMatchers.equalTo(1)));
+        assertThat(oocut.getTracks().get(0), CoreMatchers.is(CoreMatchers.equalTo(expectedTrack)));
+    }
+
+    /**
+     * Ensures tracks are sorted before they are composed to a Track list.
+     */
+    @Test
+    void testTracks_toSortTracks() throws ParseException {
+        // Arrange
+        final var buckets = generateTrackBuckets(1, 1, Modality.BICYCLE);
+        buckets.addAll(generateTrackBuckets(0, 1, Modality.WALKING));
+
+        // Act
+        final var oocut = new Measurement(buckets);
+
+        // Assert
+        final var expectedTracks = generateMeasurement( 2, new Modality[] {Modality.WALKING, Modality.BICYCLE})
+                .getTracks();
+        assertThat(oocut.getTracks(), CoreMatchers.is(CoreMatchers.equalTo(expectedTracks)));
+    }
+
+    /**
+     * Ensures data in the current database format ("track buckets") can be converted to {@code Measurement}s.
+     */
+    @ParameterizedTest
+    @MethodSource("provideTrackBucketsForMeasurements")
+    void testMeasurement(final List<TrackBucket> buckets, final Measurement expectedMeasurement) {
+        // Act
+        final var oocut = new Measurement(buckets);
+
+        // Assert
+        assertThat(oocut, CoreMatchers.is(CoreMatchers.equalTo(expectedMeasurement)));
+    }
+
+    private static Stream<Arguments> provideTrackBucketsForMeasurements() throws ParseException {
+
+        // Small test case
+        final var singleMeasurementBuckets = generateTrackBuckets(0, 1, Modality.BICYCLE);
+        final var singleMeasurement = generateMeasurement( 1, new Modality[] {Modality.BICYCLE});
+
+        // Multiple tracks in one measurement
+        final var multipleTracksBuckets = generateTrackBuckets(0, 1, Modality.BICYCLE);
+        multipleTracksBuckets.addAll(generateTrackBuckets(1, 1, Modality.BICYCLE));
+        final var multipleTracksMeasurement = generateMeasurement( 2, new Modality[] {Modality.BICYCLE});
+
+        // Multiple buckets in one track
+        final var multipleBucketsBuckets = generateTrackBuckets(0, 2, Modality.BICYCLE);
+        final var multipleBucketsMeasurement = generateMeasurement( 1, new Modality[] {Modality.BICYCLE});
+
+        return Stream.of(
+                Arguments.of(singleMeasurementBuckets, singleMeasurement),
+                Arguments.of(multipleTracksBuckets, multipleTracksMeasurement),
+                Arguments.of(multipleBucketsBuckets, multipleBucketsMeasurement));
+    }
+
+    private static List<TrackBucket> generateTrackBuckets(final int trackId,
+            final int numberOfTrackBuckets, final Modality modality) throws ParseException {
+
+        Validate.isTrue(numberOfTrackBuckets <= 3, "Not implemented for larger data sets");
+
+        final var metaData = metaData();
+        final var identifier = metaData.getIdentifier();
+
+        final var locations = new ArrayList<RawRecord>();
+        locations.add(new RawRecord(identifier, 1608650009000L, 51.075295000000004, 13.772176666666667, null, 27.04,
+                13.039999961853027, modality));
+        locations.add(new RawRecord(identifier, 1608650010000L, 51.0753, 13.77215, null, 16.85,
+                13.039999961853027, modality));
+        locations.add(new RawRecord(identifier, 1608650010000L, 51.0753, 13.77215, null, 27.25,
+                13.039999961853027, modality));
+
+        final var trackBuckets = new ArrayList<TrackBucket>();
+        for (int i = 0; i < numberOfTrackBuckets; i++) {
+            final var isLastBucket = i == numberOfTrackBuckets - 1;
+            final var minute = 13 + i;
+            final var locationsSlice = new ArrayList<RawRecord>();
+            if (isLastBucket) {
+                locationsSlice.addAll(locations);
+            } else {
+                locationsSlice.add(locations.get(0));
+                locations.remove(0);
+            }
+            // noinspection SpellCheckingInspection
+            final var date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse("2020-12-22T15:" + minute + ":00Z");
+            final var track = new Track(locationsSlice, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+            trackBuckets.add(new TrackBucket(trackId, date, track, metaData));
+        }
+
+        return trackBuckets;
+    }
+
+    private static Measurement generateMeasurement(final int numberOfTracks, final Modality[] modalities) {
+        Validate.isTrue(modalities.length <= 2, "Not implemented");
+
+        final var expectedMetaData = metaData();
+        final var measurementIdentifier = metaData().getIdentifier();
+        final var expectedTracks = new ArrayList<Track>();
+        for (int i = 0; i < numberOfTracks; i++) {
+            final var modality = modalities.length == 1 ? modalities[0] : i == 0 ? modalities[0] : modalities[1];
+            final var expectedLocations = new ArrayList<RawRecord>();
+            expectedLocations.add(new RawRecord(measurementIdentifier, 1608650009000L,
+                    51.075295000000004, 13.772176666666667, 27.04, 13.039999961853027, modality));
+            expectedLocations.add(new RawRecord(measurementIdentifier, 1608650010000L,
+                    51.0753, 13.77215, 16.85, 13.039999961853027, modality));
+            expectedLocations.add(new RawRecord(measurementIdentifier, 1608650010000L,
+                    51.0753, 13.77215, 27.25, 13.039999961853027, modality));
+            expectedTracks.add(new Track(expectedLocations, new ArrayList<>(), new ArrayList<>(), new ArrayList<>()));
+        }
+        return new Measurement(expectedMetaData, expectedTracks);
+    }
+
+    /**
      * @param index The 1-based index of the latitude to generate
      * @return A valid latitude value (although it might semantically make no sense)
      */
@@ -266,7 +405,7 @@ public class MeasurementTest {
     /**
      * @return A static set of metadata to be used by test {@link Measurement} instances
      */
-    private MetaData metaData() {
+    private static MetaData metaData() {
         return new MetaData(new MeasurementIdentifier(DEVICE_IDENTIFIER, MEASUREMENT_IDENTIFIER),
                 "Android SDK built for x86", "Android 8.0.0",
                 "2.7.0-beta1", 0.0, TEST_USER_ID, MetaData.CURRENT_VERSION);

--- a/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
+++ b/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.1
+ * @version 1.0.2
  */
 public class MeasurementTest {
 
@@ -269,6 +269,6 @@ public class MeasurementTest {
     private MetaData metaData() {
         return new MetaData(new MeasurementIdentifier(DEVICE_IDENTIFIER, MEASUREMENT_IDENTIFIER),
                 "Android SDK built for x86", "Android 8.0.0",
-                "2.7.0-beta1", 0.0, TEST_USER_ID, "1.0.0");
+                "2.7.0-beta1", 0.0, TEST_USER_ID, MetaData.CURRENT_VERSION);
     }
 }


### PR DESCRIPTION
This PR mostly adds old models and classes from the time before we switched to the new binary format to be able to deserialized binary v1 data. I left a comment at the beginning of each class which was just copy+pasted, which should speed up your pre-review.

Not much to review in this PR.