### PR TITLE
Task/dat 1155 small fixes

### DIFF
--- a/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
@@ -55,7 +55,7 @@ import de.cyface.model.RawRecord;
  * key into the database.
  * 
  * @author Klemens Muthmann
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
@@ -267,8 +267,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
         final var lengthResultSet = lengthQuery.executeQuery();
         lengthResultSet.next();
         final var length = lengthResultSet.getDouble(1);
-        final var version = "1";
-        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, userId, version);
+        return new MetaData(measurementIdentifier, deviceType, osVersion, appVersion, length, userId, MetaData.CURRENT_VERSION);
     }
 
     /**

--- a/libs/model/src/main/java/de/cyface/model/Json.java
+++ b/libs/model/src/main/java/de/cyface/model/Json.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @author Armin Schnabel
  * @since 1.1.0
- * @version 1.1.1
+ * @version 1.2.0
  */
 public class Json {
 
@@ -207,13 +207,24 @@ public class Json {
             private final List<KeyValuePair> keyValuePairs = new ArrayList<>();
 
             /**
-             * Adds the supplied {@code objects} to this builder.
+             * Adds the supplied {@code pair} to this builder.
              *
              * @param pair the {@link KeyValuePair} to add
              * @return this builder
              */
             public Builder add(final KeyValuePair pair) {
                 this.keyValuePairs.add(pair);
+                return this;
+            }
+
+            /**
+             * Adds the supplied {@code pairs} to this builder.
+             *
+             * @param pairs the {@link KeyValuePair}s to add
+             * @return this builder
+             */
+            public Builder addAll(final KeyValuePair... pairs) {
+                this.keyValuePairs.addAll(List.of(pairs));
                 return this;
             }
 
@@ -278,13 +289,24 @@ public class Json {
             private final List<JsonObject> objects = new ArrayList<>();
 
             /**
-             * Adds the supplied {@code objects} to this builder.
+             * Adds the supplied {@code object} to this builder.
              *
              * @param object the {@link JsonObject} to add
              * @return this builder
              */
             public Builder add(final JsonObject object) {
                 this.objects.add(object);
+                return this;
+            }
+
+            /**
+             * Adds the supplied {@code objects} to this builder.
+             *
+             * @param objects the {@link JsonObject}s to add
+             * @return this builder
+             */
+            public Builder addAll(final JsonObject... objects) {
+                this.objects.addAll(List.of(objects));
                 return this;
             }
 

--- a/libs/model/src/main/java/de/cyface/model/MetaData.java
+++ b/libs/model/src/main/java/de/cyface/model/MetaData.java
@@ -18,6 +18,8 @@
  */
 package de.cyface.model;
 
+import org.apache.commons.lang3.Validate;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -25,17 +27,21 @@ import java.util.Objects;
  * The context of a {@code Measurement}.
  *
  * @author Armin Schnabel
- * @version 2.0.0
+ * @version 2.0.1
  * @since 1.2.0
  */
 public class MetaData implements Serializable {
 
     /**
-     * The version of the deserialized measurement model.
+     * The current version of the deserialized measurement model.
      * <p>
      * Required to read measurement documents from the database which were deserialized by different deserializers.
      */
     public static final String CURRENT_VERSION = "2.0.0";
+    /**
+     * Regex of supported {@link MetaData} versions of this class.
+     */
+    public static final String SUPPORTED_VERSIONS = "2.[0-9]+.[0-9]+";
     /**
      * Used to serialize objects of this class. Only change this value if this classes attribute set changes.
      */
@@ -65,7 +71,7 @@ public class MetaData implements Serializable {
      */
     private String userId;
     /**
-     * The version of the {@code Measurement} model in the deserialized format, such as "1.1.1" or "2.0.0".
+     * The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
      */
     private String version;
 
@@ -78,10 +84,12 @@ public class MetaData implements Serializable {
      * @param appVersion The version of the app that transmitted the measurement, such as "1.2.0" or "1.2.0-beta1".
      * @param length The length of the measurement in meters.
      * @param userId The id of the user who has uploaded this measurement.
-     * @param version The version of this {@code Measurement} model, such as "1.1.1" or "2.0.0".
+     * @param version The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
      */
     public MetaData(final MeasurementIdentifier identifier, final String deviceType, final String osVersion,
             final String appVersion, final double length, final String userId, final String version) {
+
+        Validate.isTrue(version.matches(SUPPORTED_VERSIONS), "Unsupported version: %s", version);
         this.identifier = identifier;
         this.deviceType = deviceType;
         this.osVersion = osVersion;

--- a/libs/model/src/main/java/de/cyface/model/TrackBucket.java
+++ b/libs/model/src/main/java/de/cyface/model/TrackBucket.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021-2022 Cyface GmbH
+ *
+ * This file is part of the Serialization.
+ *
+ * The Serialization is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Serialization is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Serialization. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.model;
+
+import java.util.Date;
+
+/**
+ * The mongo database "bucket" which contains a slice of a track.
+ *
+ * @author Armin Schnabel
+ * @since 1.5.0
+ * @version 1.0.0
+ */
+@SuppressWarnings("unused") // Part of the API
+public class TrackBucket {
+
+    /**
+     * The track's position within the measurement.
+     */
+    final int trackId;
+    /**
+     * The time "slice" of the bucket.
+     */
+    final Date bucket;
+    /**
+     * The track slice of the bucket.
+     */
+    final Track track;
+    /**
+     * The {@link MetaData} of the track.
+     */
+    final MetaData metaData;
+
+    /**
+     * Initialized a fully constructed instance of this class.
+     *
+     * @param trackId The track's position within the measurement.
+     * @param bucket The time "slice" of the bucket.
+     * @param track The track slice of the bucket.
+     * @param metaData The {@link MetaData} of the track.
+     */
+    public TrackBucket(final int trackId, final Date bucket, final Track track, final MetaData metaData) {
+        this.trackId = trackId;
+        this.bucket = bucket;
+        this.track = track;
+        this.metaData = metaData;
+    }
+
+    /**
+     * @return The track's position within the measurement.
+     */
+    public int getTrackId() {
+        return trackId;
+    }
+
+    /**
+     * @return The time "slice" of the bucket.
+     */
+    public Date getBucket() {
+        return bucket;
+    }
+
+    /**
+     * @return The track slice of the bucket.
+     */
+    public Track getTrack() {
+        return track;
+    }
+
+    /**
+     * @return The {@link MetaData} of the track.
+     */
+    public MetaData getMetaData() {
+        return metaData;
+    }
+}


### PR DESCRIPTION
We don't want the v1 data format support in the main, but the changes below from the original [PR](https://github.com/cyface-de/serialization/pull/31) still makes sense or are necessary in order to use deserialized data in the pipelines instead of deserializing the data again for each pipeline.