### PR TITLE
[RFR-634] Switch to userId as UUID

### DIFF
--- a/libs/deserializer/src/main/java/de/cyface/deserializer/DeserializerFactory.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/DeserializerFactory.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 
 import de.cyface.model.MetaData;
 
@@ -29,7 +30,7 @@ import de.cyface.model.MetaData;
  * A collection of static factory methods to hide the possible complexity of {@link Deserializer} creation.
  * 
  * @author Klemens Muthmann
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public final class DeserializerFactory {
@@ -70,7 +71,7 @@ public final class DeserializerFactory {
      * @param directionsArchive The archive containing directions from the compass
      * @return A {@link ZippedPhoneDataDeserializer} to read measurements from a phone export
      */
-    public static ZippedPhoneDataDeserializer create(final String userId, final Path measuresArchive,
+    public static ZippedPhoneDataDeserializer create(final UUID userId, final Path measuresArchive,
             final Path accelerationsArchive, final Path rotationsArchive, final Path directionsArchive) {
         return new ZippedPhoneDataDeserializer(userId, measuresArchive, accelerationsArchive, rotationsArchive,
                 directionsArchive);
@@ -89,7 +90,7 @@ public final class DeserializerFactory {
      * @param directionFiles The files containing the directions from the compass for each measurement
      * @return A {@link UnzippedPhoneDataDeserializer} to read measurements from an unzipped phone export
      */
-    public static UnzippedPhoneDataDeserializer create(final String userId, final Path measuresDatabase,
+    public static UnzippedPhoneDataDeserializer create(final UUID userId, final Path measuresDatabase,
                                                        final List<Path> accelerationFiles, final List<Path> rotationFiles, final List<Path> directionFiles) {
         return new UnzippedPhoneDataDeserializer(userId, measuresDatabase, accelerationFiles, rotationFiles, directionFiles);
     }

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/PhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/PhoneDataDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Cyface GmbH
+ * Copyright 2020-2023 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -22,6 +22,13 @@ import org.apache.commons.lang3.Validate;
 
 import de.cyface.model.Measurement;
 
+/**
+ * Reads a measurement from the Cyface binary format.
+ *
+ * @author Armin Schnabel
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 public abstract class PhoneDataDeserializer implements Deserializer {
     /**
      * The running number of the {@link Measurement} to deserialize on the next call to {@link #read()}. Since each

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/UnzippedPhoneDataDeserializer.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang3.Validate;
 
@@ -55,7 +56,7 @@ import de.cyface.model.RawRecord;
  * key into the database.
  * 
  * @author Klemens Muthmann
- * @version 1.0.1
+ * @version 1.0.2
  * @since 1.0.0
  */
 public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
@@ -103,7 +104,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * The user id used to identify the deserialized information. This is lost during export. It does not matter to use
      * the correct one here, but a user id is often necessary for further processing steps.
      */
-    private final String userId;
+    private final UUID userId;
 
     /**
      * Create a new {@link Deserializer} for phone data. Before calling read on an instance of this class
@@ -119,7 +120,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * @param rotationsFilePaths The files containing the gyroscope sensor data
      * @param directionsFilePaths The files containing the compass sensor data
      */
-    UnzippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath,
+    UnzippedPhoneDataDeserializer(final UUID userId, final Path sqliteDatabasePath,
                                   final List<Path> accelerationsFilePaths,
                                   final List<Path> rotationsFilePaths, final List<Path> directionsFilePaths) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
@@ -129,7 +130,7 @@ public class UnzippedPhoneDataDeserializer extends PhoneDataDeserializer {
                 .reduce((first, second) -> first || second).orElseThrow());
         Validate.isTrue(directionsFilePaths.stream().map(Files::exists)
                 .reduce((first, second) -> first || second).orElseThrow());
-        Validate.notEmpty(userId);
+        Validate.notNull(userId);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePaths = accelerationsFilePaths;

--- a/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
+++ b/libs/deserializer/src/main/java/de/cyface/deserializer/ZippedPhoneDataDeserializer.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -41,7 +42,7 @@ import de.cyface.model.MeasurementIdentifier;
  * metadata. The other three contain the sensor data from the accelerometer, the gyroscope and the compass.
  * 
  * @author Klemens Muthmann
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
@@ -71,7 +72,7 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * The userId to identify the deserialized information. This is lost during export. It is not necessary
      * to use the correct one here, but a userId is often necessary for further processing steps
      */
-    private final String userId;
+    private final UUID userId;
     /**
      * The path in the local file system to the SQLite database with the location and event
      * information
@@ -102,13 +103,13 @@ public class ZippedPhoneDataDeserializer extends PhoneDataDeserializer {
      * @param rotationsFilePath The archive containing rotations from the gyroscope
      * @param directionsFilePath The archive containing directions from the compass
      */
-    ZippedPhoneDataDeserializer(final String userId, final Path sqliteDatabasePath, final Path accelerationsFilePath,
+    ZippedPhoneDataDeserializer(final UUID userId, final Path sqliteDatabasePath, final Path accelerationsFilePath,
             final Path rotationsFilePath, final Path directionsFilePath) {
         Validate.isTrue(Files.exists(sqliteDatabasePath));
         Validate.isTrue(Files.exists(accelerationsFilePath));
         Validate.isTrue(Files.exists(rotationsFilePath));
         Validate.isTrue(Files.exists(directionsFilePath));
-        Validate.notEmpty(userId);
+        Validate.notNull(userId);
 
         this.sqliteDatabasePath = sqliteDatabasePath;
         this.accelerationsFilePath = accelerationsFilePath;

--- a/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
+++ b/libs/deserializer/src/test/java/de/cyface/deserializer/BinaryFormatDeserializerTest.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.DisplayName;
@@ -75,7 +76,7 @@ import de.cyface.serializer.Serializer;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 class BinaryFormatDeserializerTest {
@@ -93,7 +94,7 @@ class BinaryFormatDeserializerTest {
     /**
      * The id of the user to add test data for.
      */
-    private static final String TEST_USER_ID = "624d8c51c0879068499676c6";
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
 
     private final static short PERSISTENCE_FILE_FORMAT_VERSION = 3;
 

--- a/libs/deserializer/src/test/java/de/cyface/deserializer/UnzippedPhoneDataDeserializerTest.java
+++ b/libs/deserializer/src/test/java/de/cyface/deserializer/UnzippedPhoneDataDeserializerTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang3.Validate;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +60,7 @@ public class UnzippedPhoneDataDeserializerTest {
         final var directionsLocation = path(folder + mid + ".cyfd");
         final var rotationsLocation = path(folder + mid + ".cyfr");
 
-        final var oocut = new UnzippedPhoneDataDeserializer("test-user", databaseLocation,
+        final var oocut = new UnzippedPhoneDataDeserializer(UUID.randomUUID(), databaseLocation,
                 List.of(accelerationsLocation), List.of(rotationsLocation), List.of(directionsLocation));
 
         // Act
@@ -91,7 +92,7 @@ public class UnzippedPhoneDataDeserializerTest {
         final var accelerations = path(folder + "cyface-accelerations" + suffix);
         final var directions = path(folder + "cyface-directions" + suffix);
         final var rotations = path(folder + "cyface-rotations" + suffix);
-        final var oocut = new ZippedPhoneDataDeserializer("test-user", databaseLocation, accelerations, directions,
+        final var oocut = new ZippedPhoneDataDeserializer(UUID.randomUUID(), databaseLocation, accelerations, directions,
                 rotations);
 
         // Act

--- a/libs/model/src/main/java/de/cyface/model/CalibrationJob.java
+++ b/libs/model/src/main/java/de/cyface/model/CalibrationJob.java
@@ -18,11 +18,13 @@
  */
 package de.cyface.model;
 
+import java.util.UUID;
+
 /**
  * A {@link Job} which contains details about filtered data during calibration.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 2.0.0
  * @since 2.3.1
  */
 @SuppressWarnings("unused") // Part of the API
@@ -53,8 +55,8 @@ public class CalibrationJob extends Job {
      * @param processable {@code true} when the measurement contains processable tracks.
      * @param totalLocations The number of locations to be processed for this job.
      */
-    public CalibrationJob(final String id, final String startedBy, final boolean processable,
-            final int totalLocations) {
+    public CalibrationJob(final String id, final UUID startedBy, final boolean processable,
+                          final int totalLocations) {
         super(id, startedBy);
         this.processable = processable;
         this.totalLocations = totalLocations;

--- a/libs/model/src/main/java/de/cyface/model/Job.java
+++ b/libs/model/src/main/java/de/cyface/model/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Cyface GmbH
+ * Copyright 2022-2023 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -20,6 +20,7 @@ package de.cyface.model;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.apache.commons.lang3.Validate;
 
@@ -27,7 +28,7 @@ import org.apache.commons.lang3.Validate;
  * The job which triggered pipeline processing.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 2.0.0
  * @since 2.3.0
  */
 @SuppressWarnings("unused") // Part of the API
@@ -44,7 +45,7 @@ public class Job implements Serializable {
     /**
      * The id of the user who triggered the pipeline and will own the result data.
      */
-    private final String startedBy;
+    private final UUID startedBy;
 
     /**
      * Constructs a fully initialized instance of this class.
@@ -53,9 +54,9 @@ public class Job implements Serializable {
      * @param startedBy The id of the user who triggered the pipeline and will own the result data.
      */
     @SuppressWarnings("unused") // Part of the API
-    public Job(final String id, final String startedBy) {
+    public Job(final String id, final UUID startedBy) {
         this.id = Validate.notEmpty(id);
-        this.startedBy = Validate.notEmpty(startedBy);
+        this.startedBy = Validate.notNull(startedBy);
     }
 
     /**
@@ -70,7 +71,7 @@ public class Job implements Serializable {
      * @return The id of the user who triggered the pipeline and will own the result data.
      */
     @SuppressWarnings("unused") // Part of the API
-    public String getStartedBy() {
+    public UUID getStartedBy() {
         return startedBy;
     }
 

--- a/libs/model/src/main/java/de/cyface/model/Json.java
+++ b/libs/model/src/main/java/de/cyface/model/Json.java
@@ -21,12 +21,13 @@ package de.cyface.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This class allows structuring data in the Json format without Json dependencies.
  *
  * @author Armin Schnabel
- * @since 1.1.0
+ * @since 1.2.0
  * @version 1.2.1
  */
 public class Json {
@@ -85,6 +86,18 @@ public class Json {
     public static KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key,
             final JsonObject value) {
         return new KeyValuePair("\"" + key + "\":" + value.stringValue);
+    }
+
+    /**
+     * Creates a {@link KeyValuePair} from the supplied key and value.
+     *
+     * @param key the name of the key to be used
+     * @param value the value as {@link UUID}
+     * @return the created {@code KeyValuePair}
+     */
+    public static KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key,
+                                            final UUID value) {
+        return new KeyValuePair("\"" + key + "\":" + value);
     }
 
     /**

--- a/libs/model/src/main/java/de/cyface/model/Json.java
+++ b/libs/model/src/main/java/de/cyface/model/Json.java
@@ -21,13 +21,12 @@ package de.cyface.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * This class allows structuring data in the Json format without Json dependencies.
  *
  * @author Armin Schnabel
- * @since 1.2.0
+ * @since 1.1.0
  * @version 1.2.1
  */
 public class Json {
@@ -86,18 +85,6 @@ public class Json {
     public static KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key,
             final JsonObject value) {
         return new KeyValuePair("\"" + key + "\":" + value.stringValue);
-    }
-
-    /**
-     * Creates a {@link KeyValuePair} from the supplied key and value.
-     *
-     * @param key the name of the key to be used
-     * @param value the value as {@link UUID}
-     * @return the created {@code KeyValuePair}
-     */
-    public static KeyValuePair jsonKeyValue(@SuppressWarnings("SameParameterValue") final String key,
-                                            final UUID value) {
-        return new KeyValuePair("\"" + key + "\":" + value);
     }
 
     /**

--- a/libs/model/src/main/java/de/cyface/model/Measurement.java
+++ b/libs/model/src/main/java/de/cyface/model/Measurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Cyface GmbH
+ * Copyright 2019-2023 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 2.1.0
+ * @version 2.1.1
  * @since 1.0.0
  */
 public class Measurement implements Serializable {
@@ -313,7 +313,7 @@ public class Measurement implements Serializable {
 
     private Json.JsonObject asJson(final String username, final MetaData metaData) {
         return jsonObject(
-                jsonKeyValue("userId", metaData.getUserId()),
+                jsonKeyValue("userId", metaData.getUserId().toString()),
                 jsonKeyValue("username", username),
                 jsonKeyValue("deviceId", metaData.getIdentifier().getDeviceIdentifier()),
                 jsonKeyValue("measurementId", metaData.getIdentifier().getMeasurementIdentifier()),
@@ -485,7 +485,7 @@ public class Measurement implements Serializable {
         final var measurementId = String.valueOf(metaData.getIdentifier().getMeasurementIdentifier());
 
         final var elements = new ArrayList<String>();
-        elements.add(userId);
+        elements.add(userId.toString());
         if (username != null) {
             elements.add(username);
         }

--- a/libs/model/src/main/java/de/cyface/model/MetaData.java
+++ b/libs/model/src/main/java/de/cyface/model/MetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Cyface GmbH
+ * Copyright 2020-2023 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -22,12 +22,13 @@ import org.apache.commons.lang3.Validate;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
- * The context of a {@code Measurement}.
+ * The context of a deserialized {@code Measurement}.
  *
  * @author Armin Schnabel
- * @version 2.0.1
+ * @version 3.0.0
  * @since 1.2.0
  */
 public class MetaData implements Serializable {
@@ -35,17 +36,17 @@ public class MetaData implements Serializable {
     /**
      * The current version of the deserialized measurement model.
      * <p>
-     * Required to read measurement documents from the database which were deserialized by different deserializers.
+     * To be able to read measurements deserialized by different deserializer versions.
      */
-    public static final String CURRENT_VERSION = "2.0.0";
+    public static final String CURRENT_VERSION = "3.0.0";
     /**
      * Regex of supported {@link MetaData} versions of this class.
      */
-    public static final String SUPPORTED_VERSIONS = "2.[0-9]+.[0-9]+";
+    public static final String SUPPORTED_VERSIONS = "3.0.0";
     /**
      * Used to serialize objects of this class. Only change this value if this classes attribute set changes.
      */
-    private static final long serialVersionUID = -8113278901259461591L;
+    private static final long serialVersionUID = -2781311916778609965L;
     /**
      * The worldwide unique identifier of the measurement.
      */
@@ -69,9 +70,9 @@ public class MetaData implements Serializable {
     /**
      * The id of the user who has uploaded this measurement.
      */
-    private String userId;
+    private UUID userId;
     /**
-     * The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
+     * The format version in which the {@code Measurement} was deserialized, e.g. "1.2.3".
      */
     private String version;
 
@@ -87,7 +88,7 @@ public class MetaData implements Serializable {
      * @param version The format version in which the {@code Measurement} was deserialized, e.g. "2.0.0".
      */
     public MetaData(final MeasurementIdentifier identifier, final String deviceType, final String osVersion,
-            final String appVersion, final double length, final String userId, final String version) {
+            final String appVersion, final double length, final UUID userId, final String version) {
 
         Validate.isTrue(version.matches(SUPPORTED_VERSIONS), "Unsupported version: %s", version);
         this.identifier = identifier;
@@ -145,7 +146,7 @@ public class MetaData implements Serializable {
     /**
      * @return The id of the user who has uploaded this measurement.
      */
-    public String getUserId() {
+    public UUID getUserId() {
         return userId;
     }
 
@@ -211,7 +212,7 @@ public class MetaData implements Serializable {
      * @param userId The name of the user who has uploaded this measurement.
      */
     @SuppressWarnings("unused")
-    public void setUserId(final String userId) {
+    public void setUserId(final UUID userId) {
         this.userId = userId;
     }
 

--- a/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
+++ b/libs/model/src/test/java/de/cyface/model/MeasurementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 Cyface GmbH
+ * Copyright 2020-2023 Cyface GmbH
  *
  * This file is part of the Serialization.
  *
@@ -47,7 +47,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  *
  * @author Klemens Muthmann
  * @author Armin Schnabel
- * @version 1.0.2
+ * @version 1.0.3
  */
 public class MeasurementTest {
 
@@ -67,7 +67,7 @@ public class MeasurementTest {
     /**
      * The id of the user to add test data for.
      */
-    private static final String TEST_USER_ID = "624d8c51c0879068499676c6";
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
 
     /**
      * Tests that writing the CSV header produces the correct output.


### PR DESCRIPTION
The userId is now a UUID (before a Mongo OID, stored as String).

I updated the `MetaData` which represents the metadata in `deserialized` collection and increased the version of that document/class to `3.0.0` (from `2.0.0`) so that readers of `deserialized` can decide which formats they want to support.

My guess is that we'll do a hard cut and won't support pre-OAuth data.
As this PR breaks the API of this library, I'll release it as new mayor version `serialization:3.0.0`.